### PR TITLE
Add variable renaming

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,7 +3,7 @@ module Main where
 import Minicute.Data.PrintSequence ( toString )
 import Minicute.Parser.Parser ( programL )
 import Minicute.PrettyPrintable ( prettyPrint )
-import Minicute.Transpiler.FreeVariables ( formFreeVariablesL )
+import Minicute.Transpiler.FreeVariables ( formFreeVariablesMainL )
 import System.Environment
 import System.IO
 import Text.Megaparsec ( errorBundlePretty, parse )
@@ -27,7 +27,7 @@ compile handle = do
       print program
       putStrLn "program by pretty printing:"
       putStrLn (toString (prettyPrint program))
-      let annotatedProgram = formFreeVariablesL program
+      let annotatedProgram = formFreeVariablesMainL program
       putStrLn "annotated program by show:"
       print annotatedProgram
       putStrLn "annotated program by pretty printing:"

--- a/hlint/hlint.yml
+++ b/hlint/hlint.yml
@@ -65,5 +65,6 @@
   - {name: ["Control.Monad.Combinators"], as: "Comb"}
   - {name: ["Control.Monad.Combinators.Expr"], as: "CombExpr"}
   - {name: ["Data.Set"], as: "Set"}
+  - {name: ["Data.Map"], as: "Map"}
   - {name: ["Minicute.Parser.Lexer"], as: "L"}
   - {name: ["Minicute.Parser.Parser"], as: "P"}

--- a/package.yaml
+++ b/package.yaml
@@ -96,6 +96,7 @@ tests:
     dependencies:
       - containers
       - extra
+      - lens
       - megaparsec
       - minicute
       - template-haskell

--- a/src/Minicute/Transpiler/FreeVariables.hs
+++ b/src/Minicute/Transpiler/FreeVariables.hs
@@ -2,6 +2,7 @@ module Minicute.Transpiler.FreeVariables
   ( ProgramLWithFreeVariables
   , ExpressionLWithFreeVariables
   , FreeVariables
+  , formFreeVariablesMainL
   , formFreeVariablesL
   ) where
 
@@ -20,40 +21,40 @@ type ExpressionLWithFreeVariables a = AnnotatedExpressionL FreeVariables a
 -- annotated expression
 type FreeVariables = Set.Set Identifier
 
-formFreeVariablesL :: MainProgramL -> ProgramLWithFreeVariables Identifier
-formFreeVariablesL = formFreeVariablesL' id
-{-# INLINEABLE formFreeVariablesL #-}
+formFreeVariablesMainL :: MainProgramL -> ProgramLWithFreeVariables Identifier
+formFreeVariablesMainL = formFreeVariablesL id
+{-# INLINEABLE formFreeVariablesMainL #-}
 
-formFreeVariablesL' :: (a -> Identifier) -> ProgramL a -> ProgramLWithFreeVariables a
-formFreeVariablesL' fA (ProgramL scs)
-  = AnnotatedProgramL (formFreeVariablesSc' <$> scs)
+formFreeVariablesL :: (a -> Identifier) -> ProgramL a -> ProgramLWithFreeVariables a
+formFreeVariablesL fA (ProgramL scs)
+  = AnnotatedProgramL (formFreeVariablesSc <$> scs)
     where
-      formFreeVariablesSc' (binder, args, body)
-        = (binder, args, formFVsEL' fA (Set.fromList (fA <$> args)) body)
+      formFreeVariablesSc (binder, args, body)
+        = (binder, args, formFVsEL fA (Set.fromList (fA <$> args)) body)
 
-      {-# INLINEABLE formFreeVariablesSc' #-}
-{-# INLINEABLE formFreeVariablesL' #-}
+      {-# INLINEABLE formFreeVariablesSc #-}
+{-# INLINEABLE formFreeVariablesL #-}
 
 -- |
 -- Set of identifiers those are candidates of free variables
-type FVELEnvironment' = Set.Set Identifier
+type FVELEnvironment = Set.Set Identifier
 
-formFVsEL' :: (a -> Identifier) -> FVELEnvironment' -> ExpressionL a -> ExpressionLWithFreeVariables a
-formFVsEL' _ _ (ELInteger n) = AELInteger Set.empty n
-formFVsEL' _ _ (ELConstructor tag arity) = AELConstructor Set.empty tag arity
-formFVsEL' _ env (ELVariable v) = AELVariable fvs v
+formFVsEL :: (a -> Identifier) -> FVELEnvironment -> ExpressionL a -> ExpressionLWithFreeVariables a
+formFVsEL _ _ (ELInteger n) = AELInteger Set.empty n
+formFVsEL _ _ (ELConstructor tag arity) = AELConstructor Set.empty tag arity
+formFVsEL _ env (ELVariable v) = AELVariable fvs v
   where
     fvs
       | Set.member v env = Set.singleton v
       | otherwise = Set.empty
 
     {-# INLINEABLE fvs #-}
-formFVsEL' fA env (ELApplication expr1 expr2)
+formFVsEL fA env (ELApplication expr1 expr2)
   = AELApplication (getFVOfE expr1' <> getFVOfE expr2') expr1' expr2'
   where
-    expr2' = formFVsEL' fA env expr2
-    expr1' = formFVsEL' fA env expr1
-formFVsEL' fA env (ELLet flag lDefs expr)
+    expr2' = formFVsEL fA env expr2
+    expr1' = formFVsEL fA env expr1
+formFVsEL fA env (ELLet flag lDefs expr)
   = AELLet fvs flag lDefs' expr'
   where
     fvs = fvsInLDefs' <> fvsInExpr'
@@ -64,8 +65,8 @@ formFVsEL' fA env (ELLet flag lDefs expr)
     fvsInLDefBodies' = mconcat (getFVOfE <$> lDefBodies')
 
     lDefs' = zip lDefBinders lDefBodies'
-    lDefBodies' = formFVsEL' fA lDefEnv . view letDefinitionBody <$> lDefs
-    expr' = formFVsEL' fA env' expr
+    lDefBodies' = formFVsEL fA lDefEnv . view letDefinitionBody <$> lDefs
+    expr' = formFVsEL fA env' expr
 
     env' = lDefBinderIdentifierSet <> env
     lDefEnv
@@ -81,7 +82,7 @@ formFVsEL' fA env (ELLet flag lDefs expr)
     {-# INLINEABLE fvsInLDefBodies' #-}
     {-# INLINEABLE lDefs' #-}
     {-# INLINEABLE lDefEnv #-}
-formFVsEL' fA env (ELMatch expr mCases)
+formFVsEL fA env (ELMatch expr mCases)
   = AELMatch fvs expr' mCases'
   where
     fvs = fvsInMCases' <> getFVOfE expr'
@@ -89,8 +90,8 @@ formFVsEL' fA env (ELMatch expr mCases)
     fvssInMCaseBodies' = getFVOfE <$> mCaseBodies'
 
     mCases' = zipWith (set _3) mCaseBodies' mCases
-    mCaseBodies' = zipWith (formFVsEL' fA) ((<> env) <$> mCaseArgumentSets) mCaseBodies
-    expr' = formFVsEL' fA env expr
+    mCaseBodies' = zipWith (formFVsEL fA) ((<> env) <$> mCaseArgumentSets) mCaseBodies
+    expr' = formFVsEL fA env expr
 
     mCaseBodies = view matchCaseBody <$> mCases
     mCaseArgumentSets = Set.fromList . (fA <$>) . view matchCaseArguments <$> mCases
@@ -100,13 +101,13 @@ formFVsEL' fA env (ELMatch expr mCases)
     {-# INLINEABLE fvssInMCaseBodies' #-}
     {-# INLINEABLE mCases' #-}
     {-# INLINEABLE mCaseBodies #-}
-formFVsEL' fA env (ELLambda args expr)
+formFVsEL fA env (ELLambda args expr)
   = AELLambda fvs args expr'
   where
     fvs = fvsInExpr' Set.\\ argIdentifierSet
     fvsInExpr' = getFVOfE expr'
 
-    expr' = formFVsEL' fA (argIdentifierSet <> env) expr
+    expr' = formFVsEL fA (argIdentifierSet <> env) expr
 
     argIdentifierSet = Set.fromList (fA <$> args)
 

--- a/src/Minicute/Transpiler/VariablesRenaming.hs
+++ b/src/Minicute/Transpiler/VariablesRenaming.hs
@@ -1,20 +1,141 @@
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Minicute.Transpiler.VariablesRenaming
   ( renameVariablesMainL
   ) where
 
+import Control.Lens
+import Control.Monad.State
+import Control.Monad.Reader
 import Minicute.Types.Minicute.Program
 
-type Renamer a = a -> a
+import qualified Data.Map as Map
 
-renameVariablesMainL :: Renamer MainProgramL
-renameVariablesMainL program = program
+renameVariablesMainL :: MainProgramL -> MainProgramL
+renameVariablesMainL = renameVariablesL id
 
-renameVariablesL :: Renamer a -> Renamer (ProgramL a)
-renameVariablesL = undefined
+renameVariablesL :: Lens' a Identifier -> ProgramL a -> ProgramL a
+renameVariablesL _a = renameVariables# _a (renameVariablesEL _a)
 
-renameVariables# :: Renamer a -> Renamer expr -> Renamer (Program# a expr)
-renameVariables# = undefined
+renameVariables# :: Lens' a Identifier -> Renamer expr -> Program# a expr -> Program# a expr
+renameVariables# _a rExpr
+  = flip evalState initialIdGeneratorState
+    . flip runReaderT initialRenamedRecord
+    . traverseOf _supercombinators renameVariablesScs#
+  where
+    renameVariablesScs# scs = do
+      scBinders' <- traverse renameScBinder scBinders
+      let
+        scBinderRecord = renamedRecordFromIdList (zip scBinders scBinders')
+        scs' = zipWith (set _supercombinatorBinder) scBinders' scs
+      addLocalRenamedRecord scBinderRecord
+        . traverse renameScArgumentsAndBody
+        $ scs'
+      where
+        renameScArgumentsAndBody sc = do
+          scArguments' <- traverse (renameA _a) scArguments
+          let
+            scArgumentRecord = renamedRecordFromAList _a (zip scArguments scArguments')
+            sc' = set _supercombinatorArguments scArguments' sc
+          addLocalRenamedRecord scArgumentRecord
+            . traverseOf _supercombinatorBody rExpr
+            $ sc'
+          where
+            scArguments = view _supercombinatorArguments sc
+        scBinders = view _supercombinatorBinder <$> scs
+
+    renameScBinder binder
+      | binder == "main" = return binder
+      | otherwise = renameIdentifier binder
+
+renameVariablesEL :: Lens' a Identifier -> Renamer (ExpressionL a)
+renameVariablesEL _ e@(ELInteger _) = return e
+renameVariablesEL _ e@(ELConstructor _ _) = return e
+renameVariablesEL _ e@(ELVariable v) = do
+  record <- ask
+  case Map.lookup v record of
+    Just v' -> return (ELVariable v')
+    Nothing -> return e
+renameVariablesEL _a (ELApplication e1 e2)
+  = ELApplication <$> renameVariablesEL _a e1 <*> renameVariablesEL _a e2
+renameVariablesEL _a (ELLet flag lDefs expr) = do
+  record <- ask
+  lDefBinders' <- traverse (renameA _a) lDefBinders
+  let
+    lDefBinderRecord = renamedRecordFromAList _a (zip lDefBinders lDefBinders')
+    lDefs' = zipWith (set _letDefinitionBinder) lDefBinders' lDefs
+    exprRecord = lDefBinderRecord <> record
+    lDefRecord
+      | isRecursive flag = exprRecord
+      | otherwise = record
+  lDefs'' <- setLocalRenamedRecord lDefRecord (traverse renameLDefBodies lDefs')
+  expr' <- setLocalRenamedRecord exprRecord (renameVariablesEL _a expr)
+  return (ELLet flag lDefs'' expr')
+  where
+    renameLDefBodies
+      = traverseOf _letDefinitionBody (renameVariablesEL _a)
+
+
+    lDefBinders = view _letDefinitionBinder <$> lDefs
+renameVariablesEL _a (ELMatch expr mCases) = do
+  expr' <- renameVariablesEL _a expr
+  mCases' <- traverse renameMCase mCases
+  return (ELMatch expr' mCases')
+  where
+    renameMCase mCase = do
+      mCaseArgs' <- traverse (renameA _a) mCaseArgs
+      let
+        mCaseArgRecord = renamedRecordFromAList _a (zip mCaseArgs mCaseArgs')
+        mCase' = set _matchCaseArguments mCaseArgs' mCase
+      addLocalRenamedRecord mCaseArgRecord (renameMCaseBody mCase')
+      where
+        renameMCaseBody
+          = traverseOf _matchCaseBody (renameVariablesEL _a)
+
+        mCaseArgs = view _matchCaseArguments mCase
+renameVariablesEL _a (ELLambda args expr) = do
+  args' <- traverse (renameA _a) args
+  let
+    argEnv = renamedRecordFromAList _a (zip args args')
+  expr' <- addLocalRenamedRecord argEnv (renameVariablesEL _a expr)
+  return (ELLambda args' expr')
+
+type Renamer a = a -> ReaderT RenamedRecord (State IdGeneratorState) a
+
+renameA :: Lens' a Identifier -> Renamer a
+renameA _a = traverseOf _a renameIdentifier
 
 renameIdentifier :: Renamer Identifier
-renameIdentifier = undefined
+renameIdentifier = lift . generateId
+
+setLocalRenamedRecord :: RenamedRecord -> ReaderT RenamedRecord (State IdGeneratorState) a -> ReaderT RenamedRecord (State IdGeneratorState) a
+setLocalRenamedRecord record = local (const record)
+
+addLocalRenamedRecord :: RenamedRecord -> ReaderT RenamedRecord (State IdGeneratorState) a -> ReaderT RenamedRecord (State IdGeneratorState) a
+addLocalRenamedRecord record = local (record <>)
+
+type RenamedRecord = Map.Map Identifier Identifier
+
+initialRenamedRecord :: RenamedRecord
+initialRenamedRecord = Map.empty
+
+renamedRecordFromAList :: Lens' a Identifier -> [(a, a)] -> RenamedRecord
+renamedRecordFromAList _a = renamedRecordFromIdList . (view (alongside _a _a) <$>)
+
+renamedRecordFromIdList :: [(Identifier, Identifier)] -> RenamedRecord
+renamedRecordFromIdList = Map.fromList
+
+type IdGeneratorState = Int
+
+initialIdGeneratorState :: IdGeneratorState
+initialIdGeneratorState = 0
+
+nextIdGeneratorState :: IdGeneratorState -> IdGeneratorState
+nextIdGeneratorState = (+ 1)
+
+generateId :: Identifier -> State IdGeneratorState Identifier
+generateId identifier = do
+  st <- get
+  put (nextIdGeneratorState st)
+  return (identifier <> show st)

--- a/src/Minicute/Transpiler/VariablesRenaming.hs
+++ b/src/Minicute/Transpiler/VariablesRenaming.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE MagicHash #-}
+module Minicute.Transpiler.VariablesRenaming
+  ( renameVariablesMainL
+  ) where
+
+import Minicute.Types.Minicute.Program
+
+type Renamer a = a -> a
+
+renameVariablesMainL :: Renamer MainProgramL
+renameVariablesMainL program = program
+
+renameVariablesL :: Renamer a -> Renamer (ProgramL a)
+renameVariablesL = undefined
+
+renameVariables# :: Renamer a -> Renamer expr -> Renamer (Program# a expr)
+renameVariables# = undefined
+
+renameIdentifier :: Renamer Identifier
+renameIdentifier = undefined

--- a/src/Minicute/Types/Minicute/Expression.hs
+++ b/src/Minicute/Types/Minicute/Expression.hs
@@ -25,8 +25,8 @@ module Minicute.Types.Minicute.Expression
   , LetDefinitionL
   , MainLetDefinitionL
 
-  , letDefinitionBinder
-  , letDefinitionBody
+  , _letDefinitionBinder
+  , _letDefinitionBody
 
 
   , MatchCase#
@@ -37,9 +37,9 @@ module Minicute.Types.Minicute.Expression
   , MatchCaseL
   , MainMatchCaseL
 
-  , matchCaseTag
-  , matchCaseArguments
-  , matchCaseBody
+  , _matchCaseTag
+  , _matchCaseArguments
+  , _matchCaseBody
 
 
   , Expression#( .. )
@@ -84,7 +84,7 @@ module Minicute.Types.Minicute.Expression
   , pattern AELet
   , pattern AEMatch
 
-  , annotation
+  , _annotation
 
 
   , AnnotatedExpressionL#( .. )
@@ -101,7 +101,7 @@ module Minicute.Types.Minicute.Expression
   , pattern AELMatch
   , pattern AELLambda
 
-  , annotationL
+  , _annotationL
   ) where
 
 import Control.Lens
@@ -136,13 +136,13 @@ type MainLetDefinition = LetDefinition Identifier
 type LetDefinitionL a = LetDefinition# ExpressionL a
 type MainLetDefinitionL = LetDefinitionL Identifier
 
-letDefinitionBinder :: Lens' (LetDefinition# expr_ a) a
-letDefinitionBinder = _1
-{-# INLINEABLE letDefinitionBinder #-}
+_letDefinitionBinder :: Lens' (LetDefinition# expr_ a) a
+_letDefinitionBinder = _1
+{-# INLINEABLE _letDefinitionBinder #-}
 
-letDefinitionBody :: Lens (LetDefinition# expr_ a) (LetDefinition# expr_' a) (expr_ a) (expr_' a)
-letDefinitionBody = _2
-{-# INLINEABLE letDefinitionBody #-}
+_letDefinitionBody :: Lens (LetDefinition# expr_ a) (LetDefinition# expr_' a) (expr_ a) (expr_' a)
+_letDefinitionBody = _2
+{-# INLINEABLE _letDefinitionBody #-}
 
 
 type MatchCase# expr_ a = (Int, [a], expr_ a)
@@ -152,17 +152,17 @@ type MainMatchCase = MatchCase Identifier
 type MatchCaseL a = MatchCase# ExpressionL a
 type MainMatchCaseL = MatchCaseL Identifier
 
-matchCaseTag :: Lens' (MatchCase# expr_ a) Int
-matchCaseTag = _1
-{-# INLINEABLE matchCaseTag #-}
+_matchCaseTag :: Lens' (MatchCase# expr_ a) Int
+_matchCaseTag = _1
+{-# INLINEABLE _matchCaseTag #-}
 
-matchCaseArguments :: Lens' (MatchCase# expr_ a) [a]
-matchCaseArguments = _2
-{-# INLINEABLE matchCaseArguments #-}
+_matchCaseArguments :: Lens' (MatchCase# expr_ a) [a]
+_matchCaseArguments = _2
+{-# INLINEABLE _matchCaseArguments #-}
 
-matchCaseBody :: Lens (MatchCase# expr_ a) (MatchCase# expr_' a) (expr_ a) (expr_' a)
-matchCaseBody = _3
-{-# INLINEABLE matchCaseBody #-}
+_matchCaseBody :: Lens (MatchCase# expr_ a) (MatchCase# expr_' a) (expr_ a) (expr_' a)
+_matchCaseBody = _3
+{-# INLINEABLE _matchCaseBody #-}
 
 
 data Expression# expr_ a
@@ -307,12 +307,12 @@ instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedExpression ann a)
     = showParen (p > appPrec)
       $ showString "AEMatch " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 e . showString " " . showsPrec appPrec1 mcs
 
-annotation :: Lens' (AnnotatedExpression ann a) ann
-annotation = lens getter setter
+_annotation :: Lens' (AnnotatedExpression ann a) ann
+_annotation = lens getter setter
   where
     getter (AnnotatedExpression ann _) = ann
     setter (AnnotatedExpression _ expr) ann = AnnotatedExpression ann expr
-{-# INLINEABLE annotation #-}
+{-# INLINEABLE _annotation #-}
 
 
 newtype AnnotatedExpressionL# ann expr_ a
@@ -365,9 +365,9 @@ instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedExpressionL ann a
     = showParen (p > appPrec)
       $ showString "AELLambda " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 as . showString " " . showsPrec appPrec1 e
 
-annotationL :: Lens' (AnnotatedExpressionL ann a) ann
-annotationL = lens getter setter
+_annotationL :: Lens' (AnnotatedExpressionL ann a) ann
+_annotationL = lens getter setter
   where
     getter (AnnotatedExpressionL ann _) = ann
     setter (AnnotatedExpressionL _ expr) ann = AnnotatedExpressionL ann expr
-{-# INLINEABLE annotationL #-}
+{-# INLINEABLE _annotationL #-}

--- a/src/Minicute/Types/Minicute/Program.hs
+++ b/src/Minicute/Types/Minicute/Program.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LiberalTypeSynonyms #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
 module Minicute.Types.Minicute.Program
   ( module Minicute.Types.Minicute.Expression
 
@@ -20,9 +21,9 @@ module Minicute.Types.Minicute.Program
 
   , AnnotatedSupercombinatorL
 
-  , supercombinatorBinder
-  , supercombinatorArguments
-  , supercombinatorBody
+  , _supercombinatorBinder
+  , _supercombinatorArguments
+  , _supercombinatorBody
 
 
   , Program#( .. )
@@ -43,6 +44,9 @@ module Minicute.Types.Minicute.Program
 
   , AnnotatedProgramL
   , pattern AnnotatedProgramL
+
+
+  , _supercombinators
   ) where
 
 import Control.Lens
@@ -63,17 +67,17 @@ type AnnotatedSupercombinator ann a = Supercombinator# a (AnnotatedExpression an
 
 type AnnotatedSupercombinatorL ann a = Supercombinator# a (AnnotatedExpressionL ann a)
 
-supercombinatorBinder :: Lens' (Supercombinator# a expr) Identifier
-supercombinatorBinder = _1
-{-# INLINEABLE supercombinatorBinder #-}
+_supercombinatorBinder :: Lens' (Supercombinator# a expr) Identifier
+_supercombinatorBinder = _1
+{-# INLINEABLE _supercombinatorBinder #-}
 
-supercombinatorArguments :: Lens' (Supercombinator# a expr) [a]
-supercombinatorArguments = _2
-{-# INLINEABLE supercombinatorArguments #-}
+_supercombinatorArguments :: Lens' (Supercombinator# a expr) [a]
+_supercombinatorArguments = _2
+{-# INLINEABLE _supercombinatorArguments #-}
 
-supercombinatorBody :: Lens (Supercombinator# a expr1) (Supercombinator# a expr2) expr1 expr2
-supercombinatorBody = _3
-{-# INLINEABLE supercombinatorBody #-}
+_supercombinatorBody :: Lens (Supercombinator# a expr1) (Supercombinator# a expr2) expr1 expr2
+_supercombinatorBody = _3
+{-# INLINEABLE _supercombinatorBody #-}
 
 
 newtype Program# a expr
@@ -124,3 +128,10 @@ showProgram# name p (Program# scs)
   = showParen (p > appPrec)
     $ showString name . showsPrec appPrec1 scs
 {-# INLINEABLE showProgram# #-}
+
+_supercombinators :: Lens (Program# a expr) (Program# a' expr') [Supercombinator# a expr] [Supercombinator# a' expr']
+_supercombinators = lens getter setter
+  where
+    getter (Program# scs) = scs
+    setter _ = Program#
+{-# INLINEABLE _supercombinators #-}

--- a/test/Minicute/Parser/ParserSpec.hs
+++ b/test/Minicute/Parser/ParserSpec.hs
@@ -55,14 +55,14 @@ testCases
 
 simpleTestTemplates :: [(TestContent, TestResult)]
 simpleTestTemplates
-  = [ ( [qqMini||]
+  = [ ( [qqCode||]
       , TestSuccess
         ( ProgramL
           [
           ]
         )
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f = 1
         |]
       , TestSuccess
@@ -74,7 +74,7 @@ simpleTestTemplates
           ]
         )
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f = 1;
         |]
       , TestSuccess
@@ -86,7 +86,7 @@ simpleTestTemplates
           ]
         )
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f=1;
         |]
       , TestSuccess
@@ -98,7 +98,7 @@ simpleTestTemplates
           ]
         )
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f= 1;
         |]
       , TestSuccess
@@ -110,7 +110,7 @@ simpleTestTemplates
           ]
         )
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f= 1 ;
         |]
       , TestSuccess
@@ -122,7 +122,7 @@ simpleTestTemplates
           ]
         )
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f = 1;
           g = 2
            |]
@@ -139,7 +139,7 @@ simpleTestTemplates
           ]
         )
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f = 1  ;
           g=2 ;
            |]
@@ -156,7 +156,7 @@ simpleTestTemplates
           ]
         )
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f = g;
           g = 2
            |]
@@ -173,7 +173,7 @@ simpleTestTemplates
           ]
         )
       )
-    , ( [qqMini|
+    , ( [qqCode|
                matchx = matchx
         |]
       , TestSuccess
@@ -185,31 +185,31 @@ simpleTestTemplates
           ]
         )
       )
-    , ( [qqMini|
+    , ( [qqCode|
                1f = 2
         |]
       , TestFail
         (err 0 (utok '1' <> elabel "identifier" <> eeof))
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f;
         |]
       , TestFail
         (err 1 (utok ';' <> etok '=' <> elabel "alphanumeric character" <> etok '_' <> elabel "identifier"))
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f =;
         |]
       , TestFail
         (err 3 (utok ';' <> elabel "expression"))
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f! = 5;
         |]
       , TestFail
         (err 1 (utok '!' <> etok '=' <> elabel "alphanumeric character" <> etok '_' <> elabel "identifier"))
       )
-    , ( [qqMini|
+    , ( [qqCode|
                f = 5;;
         |]
       , TestFail
@@ -220,7 +220,7 @@ simpleTestTemplates
 arithmeticOperatorTestCases :: [TestCase]
 arithmeticOperatorTestCases
   = [ ( "addition of two numbers"
-      , [qqMini|
+      , [qqCode|
                f = 1 + 1
         |]
       , TestSuccess
@@ -233,7 +233,7 @@ arithmeticOperatorTestCases
         )
       )
     , ( "addition of a number and a variable"
-      , [qqMini|
+      , [qqCode|
                f = 1 * g;
                g = 3
         |]
@@ -251,7 +251,7 @@ arithmeticOperatorTestCases
         )
       )
     , ( "multiple addition of numbers"
-      , [qqMini|
+      , [qqCode|
                f = 1 + (3 + 4)
         |]
       , TestSuccess
@@ -267,7 +267,7 @@ arithmeticOperatorTestCases
         )
       )
     , ( "operator association of -"
-      , [qqMini|
+      , [qqCode|
                f = 3 - 2 - 1
         |]
       , TestSuccess
@@ -286,7 +286,7 @@ arithmeticOperatorTestCases
         )
       )
     , ( "operator precedence of + and *"
-      , [qqMini|
+      , [qqCode|
                f = 1 * 2 + 3
         |]
       , TestSuccess
@@ -305,14 +305,14 @@ arithmeticOperatorTestCases
         )
       )
     , ( "left partial application of arithmetic operator"
-      , [qqMini|
+      , [qqCode|
                f = 2 +
         |]
       , TestFail
         (err 7 (ueof <> elabel "expression with parentheses" <> elabel "constructor" <> elabel "integer" <> elabel "variable"))
       )
     , ( "right partial application of arithmetic operator"
-      , [qqMini|
+      , [qqCode|
                f = + 2
         |]
       , TestFail
@@ -323,7 +323,7 @@ arithmeticOperatorTestCases
 constructorTestCases :: [TestCase]
 constructorTestCases
   = [ ( "basic constructor"
-      , [qqMini|
+      , [qqCode|
                f = $C{1;0};
                g = $C{2;2}
         |]
@@ -341,7 +341,7 @@ constructorTestCases
         )
       )
     , ( "constructor with arguments"
-      , [qqMini|
+      , [qqCode|
                f = $C{1;1} 5;
                g = $C{2;3} f
         |]
@@ -359,28 +359,28 @@ constructorTestCases
         )
       )
     , ( "constructor without arity"
-      , [qqMini|
+      , [qqCode|
                f = $C{1};
         |]
       , TestFail
         (err 8 (utok '}' <> etok ';' <> elabel "decimal digit"))
       )
     , ( "constructor without tag"
-      , [qqMini|
+      , [qqCode|
                f = $C{;1};
         |]
       , TestFail
         (err 7 (utok ';' <> elabel "integer"))
       )
     , ( "wrong tokens for constructor"
-      , [qqMini|
+      , [qqCode|
                f = $Co{1;1};
         |]
       , TestFail
         (err 6 (utok 'o'))
       )
     , ( "wrong tokens for constructor"
-      , [qqMini|
+      , [qqCode|
                f = $C{1,1};
         |]
       , TestFail
@@ -391,7 +391,7 @@ constructorTestCases
 applicationTestCases :: [TestCase]
 applicationTestCases
   = [ ( "application of an integer"
-      , [qqMini|
+      , [qqCode|
                f = g 5
         |]
       , TestSuccess
@@ -404,7 +404,7 @@ applicationTestCases
         )
       )
     , ( "application of a variable"
-      , [qqMini|
+      , [qqCode|
                f = g f
         |]
       , TestSuccess
@@ -417,7 +417,7 @@ applicationTestCases
         )
       )
     , ( "application of wrong expression"
-      , [qqMini|
+      , [qqCode|
                f = g []
         |]
       , TestFail
@@ -428,7 +428,7 @@ applicationTestCases
 supercombinatorTestCases :: [TestCase]
 supercombinatorTestCases
   = [ ( "supercombinator with an argument"
-      , [qqMini|
+      , [qqCode|
                f x = x
         |]
       , TestSuccess
@@ -441,7 +441,7 @@ supercombinatorTestCases
         )
       )
     , ( "supercombinator with two argument"
-      , [qqMini|
+      , [qqCode|
                f x y = x y
         |]
       , TestSuccess
@@ -454,14 +454,14 @@ supercombinatorTestCases
         )
       )
     , ( "supercombinator with a number"
-      , [qqMini|
+      , [qqCode|
                f 5 = x
         |]
       , TestFail
         (err 2 (utok '5' <> elabel "identifier" <> etok '='))
       )
     , ( "supercombinator with an illegal argument"
-      , [qqMini|
+      , [qqCode|
                f $x = $x
         |]
       , TestFail
@@ -472,7 +472,7 @@ supercombinatorTestCases
 letAndLetrecTestCases :: [TestCase]
 letAndLetrecTestCases
   = [ ( "let with a single definition"
-      , [qqMini|
+      , [qqCode|
                f = let x = 5 in x
         |]
       , TestSuccess
@@ -489,7 +489,7 @@ letAndLetrecTestCases
         )
       )
     , ( "letrec with a single definition"
-      , [qqMini|
+      , [qqCode|
                f = letrec
                   x = 5
                 in x
@@ -508,7 +508,7 @@ letAndLetrecTestCases
         )
       )
     , ( "let with multiple definitions"
-      , [qqMini|
+      , [qqCode|
                f = let
                      x = 5;
                      y = 4
@@ -529,7 +529,7 @@ letAndLetrecTestCases
         )
       )
     , ( "letrec with multiple definitions"
-      , [qqMini|
+      , [qqCode|
                f = letrec
                      x = 5;
                      y = x + x;
@@ -552,7 +552,7 @@ letAndLetrecTestCases
         )
       )
     , ( "let with nested let"
-      , [qqMini|
+      , [qqCode|
                f = let
                      x = let
                            k = 5;
@@ -573,7 +573,7 @@ letAndLetrecTestCases
         )
       )
     , ( "let with nested letrec"
-      , [qqMini|
+      , [qqCode|
                f = let x = letrec k = 5 in k; in x
         |]
       , TestSuccess
@@ -590,7 +590,7 @@ letAndLetrecTestCases
         )
       )
     , ( "letrec with nested let"
-      , [qqMini|
+      , [qqCode|
                f = letrec x = let k = 5; in k in x
         |]
       , TestSuccess
@@ -607,7 +607,7 @@ letAndLetrecTestCases
         )
       )
     , ( "letrec with nested letrec"
-      , [qqMini|
+      , [qqCode|
                f = letrec
                      x = letrec
                            k = 5;
@@ -628,14 +628,14 @@ letAndLetrecTestCases
         )
       )
     , ( "let with zero definitions"
-      , [qqMini|
+      , [qqCode|
                f = let in 5
         |]
       , TestFail
         (errFancy 8 (fancy (ErrorFail "let expression should include at least one definition")))
       )
     , ( "let without in"
-      , [qqMini|
+      , [qqCode|
                f = let x = 5
         |]
       , TestFail
@@ -646,7 +646,7 @@ letAndLetrecTestCases
 matchTestCases :: [TestCase]
 matchTestCases
   = [ ( "match with a single match case"
-      , [qqMini|
+      , [qqCode|
                f = match $C{1;0} with <1> -> 5
         |]
       , TestSuccess
@@ -662,7 +662,7 @@ matchTestCases
         )
       )
     , ( "match with multiple match cases"
-      , [qqMini|
+      , [qqCode|
                f = match $C{2;0} with
                      <1> -> 5;
                      <2> -> 3;
@@ -683,7 +683,7 @@ matchTestCases
         )
       )
     , ( "match with arguments"
-      , [qqMini|
+      , [qqCode|
                f = match $C{2;2} 5 4 with
                      <1> x y -> x;
                      <2> a b -> b
@@ -702,7 +702,7 @@ matchTestCases
         )
       )
     , ( "match without a case"
-      , [qqMini|
+      , [qqCode|
                f = match $C{2;0} with
         |]
       , TestFail
@@ -713,7 +713,7 @@ matchTestCases
 lambdaTestCases :: [TestCase]
 lambdaTestCases
   = [ ( "lambda with a single argument"
-      , [qqMini|
+      , [qqCode|
                f = \x -> x
         |]
       , TestSuccess
@@ -728,7 +728,7 @@ lambdaTestCases
         )
       )
     , ( "lambda with multiple arguments"
-      , [qqMini|
+      , [qqCode|
                f = \x y -> x + y
         |]
       , TestSuccess
@@ -743,7 +743,7 @@ lambdaTestCases
         )
       )
     , ( "lambda with nested lambda"
-      , [qqMini|
+      , [qqCode|
                f = \x -> \y -> x + y
         |]
       , TestSuccess
@@ -761,7 +761,7 @@ lambdaTestCases
         )
       )
     , ( "immidiate application of lambda"
-      , [qqMini|
+      , [qqCode|
                f = (\x -> x) 5
         |]
       , TestSuccess
@@ -779,14 +779,14 @@ lambdaTestCases
         )
       )
     , ( "lambda without body"
-      , [qqMini|
+      , [qqCode|
                f = \x ->
         |]
       , TestFail
         (err 9 (ueof <> elabel "expression"))
       )
     , ( "lambda without arguments"
-      , [qqMini|
+      , [qqCode|
                f = \ -> 5
         |]
       , TestFail
@@ -797,7 +797,7 @@ lambdaTestCases
 complexTestCases :: [TestCase]
 complexTestCases
   = [ ( "indirect right application of let expression"
-      , [qqMini|
+      , [qqCode|
                f = 5 + (let k = 5 in k)
         |]
       , TestSuccess
@@ -813,7 +813,7 @@ complexTestCases
         )
       )
     , ( "indirect right application of match expression"
-      , [qqMini|
+      , [qqCode|
                f = 5 + (match $C{1;0} with <1> -> 5)
         |]
       , TestSuccess
@@ -829,14 +829,14 @@ complexTestCases
         )
       )
     , ( "direct right application of let expression"
-      , [qqMini|
+      , [qqCode|
                f = 5 + let k = 5 in k
         |]
       , TestFail
         (errFancy 8 (fancy (ErrorFail "keyword \"let\" cannot be an identifier")))
       )
     , ( "direct right application of match expression"
-      , [qqMini|
+      , [qqCode|
                f = 5 + match $C{1;0} with <1> -> 5
         |]
       , TestFail

--- a/test/Minicute/PrettyPrintableSpec.hs
+++ b/test/Minicute/PrettyPrintableSpec.hs
@@ -46,52 +46,52 @@ type TestCase = (TestName, TestContent)
 testCases :: [TestCase]
 testCases
   = [ ( "empty program"
-      , [qqMini||]
+      , [qqCode||]
       )
     , ( "simple program"
-      , [qqMini|
+      , [qqCode|
                f = 5
         |]
       )
     , ( "program with multiple top-level definitions"
-      , [qqMini|
+      , [qqCode|
                f = 5;
                g = 5
         |]
       )
     , ( "program with top-level definitions with arguments"
-      , [qqMini|
+      , [qqCode|
                f x = g x 5;
                g x y = x y
         |]
       )
     , ( "program with arithmetic operators"
-      , [qqMini|
+      , [qqCode|
                f = 5 + 4
         |]
       )
     , ( "program with multiple arithmetic operators0"
-      , [qqMini|
+      , [qqCode|
                f = 5 + 4 * 5
         |]
       )
     , ( "program with multiple arithmetic operators1"
-      , [qqMini|
+      , [qqCode|
                f = (5 + 4) * 5
         |]
       )
     , ( "program with multiple arithmetic operators2"
-      , [qqMini|
+      , [qqCode|
                f = 5 - 4 - 3
         |]
       )
     , ( "program with multiple arithmetic operators3"
-      , [qqMini|
+      , [qqCode|
                f = 5 - (4 - 3)
         |]
       )
     , ( "program with let"
-      , [qqMini|
+      , [qqCode|
                f = let
                      x = 5
                    in
@@ -99,26 +99,26 @@ testCases
         |]
       )
     , ( "program with match"
-      , [qqMini|
+      , [qqCode|
                f = match x with
                      <1> -> 1;
                      <2> -> 2
         |]
       )
     , ( "program with lambda"
-      , [qqMini|
+      , [qqCode|
                f = \x ->
                      x + 4
         |]
       )
     , ( "program with an application with lambda"
-      , [qqMini|
+      , [qqCode|
                f = g (\x ->
                         x + 4)
         |]
       )
     , ( "program with an application for lambda"
-      , [qqMini|
+      , [qqCode|
                f = (\x ->
                       x + 4) (5 * 3)
         |]

--- a/test/Minicute/Transpiler/FreeVariablesSpec.hs
+++ b/test/Minicute/Transpiler/FreeVariablesSpec.hs
@@ -14,13 +14,13 @@ import qualified Data.Set as Set
 
 spec :: Spec
 spec = do
-  describe "formFreeVariablesL" $ do
-    forM_ testCases (uncurry3 formFreeVariablesLTest)
+  describe "formFreeVariablesMainL" $ do
+    forM_ testCases (uncurry3 formFreeVariablesMainLTest)
 
-formFreeVariablesLTest :: TestName -> TestBeforeContent -> TestAfterContent -> SpecWith (Arg Expectation)
-formFreeVariablesLTest name beforeContent afterContent = do
+formFreeVariablesMainLTest :: TestName -> TestBeforeContent -> TestAfterContent -> SpecWith (Arg Expectation)
+formFreeVariablesMainLTest name beforeContent afterContent = do
   it ("finds free variables for expressions in " <> name) $ do
-    formFreeVariablesL beforeContent `shouldBe` afterContent
+    formFreeVariablesMainL beforeContent `shouldBe` afterContent
 
 type TestName = String
 type TestBeforeContent = MainProgramL

--- a/test/Minicute/Transpiler/VariablesRenamingSpec.hs
+++ b/test/Minicute/Transpiler/VariablesRenamingSpec.hs
@@ -6,11 +6,7 @@ module Minicute.Transpiler.VariablesRenamingSpec
 import Test.Hspec
 
 import Control.Monad
-import Data.Tuple.Extra
-import Minicute.Transpiler.VariablesRenaming
-import Minicute.Types.Minicute.Program
-
-import qualified Data.Set as Set
+import Minicute.Parser.Parser
 
 spec :: Spec
 spec = do

--- a/test/Minicute/Transpiler/VariablesRenamingSpec.hs
+++ b/test/Minicute/Transpiler/VariablesRenamingSpec.hs
@@ -1,0 +1,31 @@
+{- HLINT ignore "Redundant do" -}
+module Minicute.Transpiler.VariablesRenamingSpec
+  ( spec
+  ) where
+
+import Test.Hspec
+
+import Control.Monad
+import Data.Tuple.Extra
+import Minicute.Transpiler.VariablesRenaming
+import Minicute.Types.Minicute.Program
+
+import qualified Data.Set as Set
+
+spec :: Spec
+spec = do
+  describe "renameVariablesMainL" $ do
+    forM_ testCases (uncurry renameVariablesMainLTest)
+
+renameVariablesMainLTest :: TestName -> TestContent -> SpecWith (Arg Expectation)
+renameVariablesMainLTest name beforeContent = do
+  it ("finds free variables for expressions in " <> name) $ do
+    1 `shouldBe` 1
+
+type TestName = String
+type TestContent = MainProgramL
+type TestCase = (TestName, TestContent)
+
+testCases :: [TestCase]
+testCases
+  = []

--- a/test/Minicute/Transpiler/VariablesRenamingSpec.hs
+++ b/test/Minicute/Transpiler/VariablesRenamingSpec.hs
@@ -1,22 +1,35 @@
 {- HLINT ignore "Redundant do" -}
+{-# LANGUAGE QuasiQuotes #-}
 module Minicute.Transpiler.VariablesRenamingSpec
   ( spec
   ) where
 
 import Test.Hspec
+import Test.Minicute.Utils
 
 import Control.Monad
+import Control.Lens
+import Data.List
 import Minicute.Parser.Parser
+import Minicute.Transpiler.VariablesRenaming
+import Minicute.Types.Minicute.Precedence
+import Minicute.Types.Minicute.Program
+import Text.Megaparsec
+
+import qualified Data.Set as Set
 
 spec :: Spec
 spec = do
   describe "renameVariablesMainL" $ do
     forM_ testCases (uncurry renameVariablesMainLTest)
 
+-- |
+-- These tests are too weak.
+-- We should add tests to check whether the dependence is preserved or not.
 renameVariablesMainLTest :: TestName -> TestContent -> SpecWith (Arg Expectation)
 renameVariablesMainLTest name beforeContent = do
-  it ("finds free variables for expressions in " <> name) $ do
-    1 `shouldBe` 1
+  it ("rename variables to avoid identifier conflicts in " <> name) $ do
+    renameVariablesMainL beforeContent `shouldSatisfy` haveNoIdentifierConflictMainL
 
 type TestName = String
 type TestContent = MainProgramL
@@ -24,4 +37,82 @@ type TestCase = (TestName, TestContent)
 
 testCases :: [TestCase]
 testCases
-  = []
+  = [ ( "questionable program0"
+      , [qqMini|
+               main = f 5 4;
+               f x y = letrec
+                         g = \z -> x + y + z;
+                         h = \x y -> x * y * g 5
+                       in
+                         h 1 y
+        |]
+      )
+    , ( "questionable program1"
+      , [qqMini|
+               main = f 5 4;
+               f x y = let
+                         g = \z -> x + y + z;
+                         h = \x y -> x * y * g 5
+                       in
+                         h 1 y;
+               g x = x / 2
+        |]
+      )
+    ]
+
+-- |
+-- This should check any conflicts of identifiers from anywhere.
+haveNoIdentifierConflictMainL :: MainProgramL -> Bool
+haveNoIdentifierConflictMainL (ProgramL scs)
+  = scIdsNoConflict
+  && (and . snd . mapAccumL haveNoIdentifierConflictMainEL scIdSet $ view supercombinatorBody <$> scs)
+  where
+    scIdsNoConflict = Set.size scIdSet == length scs
+    scIdSet = Set.fromList (view supercombinatorBinder <$> scs)
+
+haveNoIdentifierConflictMainEL :: Set.Set Identifier -> MainExpressionL -> (Set.Set Identifier, Bool)
+haveNoIdentifierConflictMainEL env (ELInteger _) = (env, True)
+haveNoIdentifierConflictMainEL env (ELConstructor _ _) = (env, True)
+haveNoIdentifierConflictMainEL env (ELVariable v) = (env, Set.notMember v env)
+haveNoIdentifierConflictMainEL env (ELApplication e1 e2)
+  = (env2, noConflict1 && noConflict2)
+  where
+    (env1, noConflict1) = haveNoIdentifierConflictMainEL env e1
+    (env2, noConflict2) = haveNoIdentifierConflictMainEL env1 e2
+haveNoIdentifierConflictMainEL env (ELLet _ lDefs expr)
+  = (exprEnv, lDefIdsNoConflict && lDefBodiesNoConflict && exprNoConflict)
+  where
+    lDefIdsNoConflict
+      = Set.disjoint env lDefIdSet
+        && length lDefIds == Set.size lDefIdSet
+    (lDefEnv, lDefBodiesNoConflict)
+      = and <$> mapAccumL haveNoIdentifierConflictMainEL (lDefIdSet <> env) lDefBodies
+    (exprEnv, exprNoConflict)
+      = haveNoIdentifierConflictMainEL lDefEnv expr
+
+    lDefBodies = view letDefinitionBody <$> lDefs
+    lDefIdSet = Set.fromList lDefIds
+    lDefIds = view letDefinitionBinder <$> lDefs
+haveNoIdentifierConflictMainEL env (ELMatch expr mCases)
+  = (mCaseEnv, exprNoConflict && mCaseArgsNoConflict && mCaseBodiesNoConflict)
+  where
+    (exprEnv, exprNoConflict)
+      = haveNoIdentifierConflictMainEL (mCaseArgIdSet <> env) expr
+    mCaseArgsNoConflict
+      = Set.disjoint env mCaseArgIdSet
+        && Set.size mCaseArgIdSet == length mCaseArgs
+    (mCaseEnv, mCaseBodiesNoConflict)
+      = and <$> mapAccumL haveNoIdentifierConflictMainEL exprEnv mCaseBodies
+
+    mCaseArgIdSet = Set.fromList mCaseArgs
+    mCaseArgs = concat (view matchCaseArguments <$> mCases)
+    mCaseBodies = view matchCaseBody <$> mCases
+haveNoIdentifierConflictMainEL env (ELLambda args expr)
+  = (exprEnv, argsNoConflict && exprNoConflict)
+  where
+    argsNoConflict
+      = Set.disjoint env argSet
+        && Set.size argSet == length args
+    (exprEnv, exprNoConflict) = haveNoIdentifierConflictMainEL (argSet <> env) expr
+
+    argSet = Set.fromList args

--- a/test/Minicute/Transpiler/VariablesRenamingSpec.hs
+++ b/test/Minicute/Transpiler/VariablesRenamingSpec.hs
@@ -65,10 +65,10 @@ testCases
 haveNoIdentifierConflictMainL :: MainProgramL -> Bool
 haveNoIdentifierConflictMainL (ProgramL scs)
   = scIdsNoConflict
-  && (and . snd . mapAccumL haveNoIdentifierConflictMainEL scIdSet $ view supercombinatorBody <$> scs)
+  && (and . snd . mapAccumL haveNoIdentifierConflictMainEL scIdSet $ view _supercombinatorBody <$> scs)
   where
     scIdsNoConflict = Set.size scIdSet == length scs
-    scIdSet = Set.fromList (view supercombinatorBinder <$> scs)
+    scIdSet = Set.fromList (view _supercombinatorBinder <$> scs)
 
 haveNoIdentifierConflictMainEL :: Set.Set Identifier -> MainExpressionL -> (Set.Set Identifier, Bool)
 haveNoIdentifierConflictMainEL env (ELInteger _) = (env, True)
@@ -90,9 +90,9 @@ haveNoIdentifierConflictMainEL env (ELLet _ lDefs expr)
     (exprEnv, exprNoConflict)
       = haveNoIdentifierConflictMainEL lDefEnv expr
 
-    lDefBodies = view letDefinitionBody <$> lDefs
+    lDefBodies = view _letDefinitionBody <$> lDefs
     lDefIdSet = Set.fromList lDefIds
-    lDefIds = view letDefinitionBinder <$> lDefs
+    lDefIds = view _letDefinitionBinder <$> lDefs
 haveNoIdentifierConflictMainEL env (ELMatch expr mCases)
   = (mCaseEnv, exprNoConflict && mCaseArgsNoConflict && mCaseBodiesNoConflict)
   where
@@ -105,8 +105,8 @@ haveNoIdentifierConflictMainEL env (ELMatch expr mCases)
       = and <$> mapAccumL haveNoIdentifierConflictMainEL exprEnv mCaseBodies
 
     mCaseArgIdSet = Set.fromList mCaseArgs
-    mCaseArgs = concat (view matchCaseArguments <$> mCases)
-    mCaseBodies = view matchCaseBody <$> mCases
+    mCaseArgs = concat (view _matchCaseArguments <$> mCases)
+    mCaseBodies = view _matchCaseBody <$> mCases
 haveNoIdentifierConflictMainEL env (ELLambda args expr)
   = (exprEnv, argsNoConflict && exprNoConflict)
   where


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Without variable renaming path, it's really hard to implement the lambda lifting.

**Describe the solution you chose**
- I use `ReaderT` monad transformer and `State` monad to access environments required by renaming process.
- By implementing `renameVariables#`, `renameVariablesEL#`, `renameVariablesE#`, making functions of various types is quite easy now.

**Describe alternatives you've considered**
- Just implementing `renameVariablesEL` directly (without `#` versions of functions)
  - It could be faster in terms of performance, but I think it's not worth enough.

