### PR TITLE
Fix parser to parse top-level definition after match expression

### DIFF
--- a/src/Minicute/Parser/Parser.hs
+++ b/src/Minicute/Parser/Parser.hs
@@ -97,7 +97,11 @@ matchExpressionL
   where
     matchCasesL
       = (notFollowedBy (separator <|> eof) <|> zeroMatchCaseError)
-        *> sepBy1 matchCaseL separator
+        *>
+        ( cons
+          <$> matchCaseL
+          <*> many (try (separator *> matchCaseL))
+        )
 
     startingKeyword = L.keyword "match"
     endingKeyword = L.keyword "with"

--- a/test/Minicute/Parser/ParserSpec.hs
+++ b/test/Minicute/Parser/ParserSpec.hs
@@ -701,6 +701,30 @@ matchTestCases
           ]
         )
       )
+    , ( "match followed by other top-level definition"
+      , [qqMini|
+               f = match $C{2;2} 5 4 with
+                     <1> x y -> x;
+                     <2> a b -> b;
+               g = 1
+        |]
+      , TestSuccess
+        ( ProgramL
+          [ ( "f"
+            , []
+            , ELMatch
+              (ELApplication2 (ELConstructor 2 2) (ELInteger 5) (ELInteger 4))
+              [ (1, ["x", "y"], ELVariable "x")
+              , (2, ["a", "b"], ELVariable "b")
+              ]
+            )
+          , ( "g"
+            , []
+            , ELInteger 1
+            )
+          ]
+        )
+      )
     , ( "match without a case"
       , [qqMini|
                f = match $C{2;0} with


### PR DESCRIPTION
**Fixed Issue(s)**
An issue has not been made.

**Root of the Bug(s)**
When parsing `;`, previous parser just use it as a separator between match cases, where in reality, it could be a separator between a supercombinator after the final match case and supercombinator that is currently in parsing.

**Previous Behaviour**
Previous parser cannot parse the following program.
```
main = match Pack{1,0} of
         <1> -> f 0;
f x = x
```

**Current Behaviour**
By updating match case parser, current parser can parse the previous example.

**Desktop (please complete the following information):**
 - OS: Manjaro
 - ~Minicute Version: Not Yet Released~
 - Underlying Compiler Version: LTS 13.17
