### PR TITLE
Update GitHub templates [skip ci]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
-# DO NOT USE THIS TEMPLATE!
+# DO NOT USE THIS TEMPLATE! Instead ...
 
-## When You Fix Bugs
-If you want to send a PR to fix some bugs, please use `?template=fix_bugs.md&labels=bug` query parameter.
+# When You Fix Bugs
+If you want to send a PR to fix some bugs, please use `?template=fix_bugs.md&labels=bug&expand=1` query parameter.
 
-## When You Make New Features
-If you want to send a PR to add a new feature, please use `?template=add_features.md&labels=enhancement` query parameter.
+# When You Make New Features
+If you want to send a PR to add a new feature, please use `?template=add_features.md&labels=enhancement&expand=1` query parameter.
 
-## How to Use Query Parameters?
+# How to Use Query Parameters?
 To know how to use query parameters, see examples in [official document from GitHub](https://help.github.com/en/articles/about-automation-for-issues-and-pull-requests-with-query-parameters#supported-query-parameters)


### PR DESCRIPTION
I'm not sure whether we need a PR template for PRs related with documentation