### PR TITLE
Add more parsers

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import Minicute.Data.PrintSequence ( toString )
-import Minicute.Parser.Parser ( programL )
+import Minicute.Parser.Parser ( mainProgramL )
 import Minicute.PrettyPrintable ( prettyPrint )
 import Minicute.Transpiler.LambdaLifting ( lambdaLifting )
 import System.Environment
@@ -21,7 +21,7 @@ compile handle = do
   putStrLn "inputs:"
   content <- hGetContents handle -- unlines <$> whileM (hIsEOF handle) (hGetLine handle)
   putChar '\n'
-  case parse programL "" content of
+  case parse mainProgramL "" content of
     Right program -> do
       putStrLn "program by show:"
       print program

--- a/src/Minicute/Parser/Parser.hs
+++ b/src/Minicute/Parser/Parser.hs
@@ -4,7 +4,7 @@ module Minicute.Parser.Parser
   ( Parser
 
   , MainProgramL
-  , programL
+  , mainProgramL
   ) where
 
 import Control.Monad.Reader ( runReaderT, mapReaderT, ask )
@@ -19,8 +19,11 @@ import qualified Control.Monad.Combinators as Comb
 import qualified Control.Monad.Combinators.Expr as CombExpr
 import qualified Minicute.Parser.Lexer as L
 
-programL :: Parser MainProgramL
-programL = program_ L.identifier (expressionL L.identifier)
+mainProgramL :: Parser MainProgramL
+mainProgramL = programL L.identifier
+
+programL :: (MonadParser e s m) => WithPrecedence m a -> m (ProgramL a)
+programL pA = program_ pA (expressionL pA)
 
 expressionL :: (MonadParser e s m) => WithPrecedence m a -> WithPrecedence m (ExpressionL a)
 expressionL pA

--- a/src/Minicute/PrettyPrintable.hs
+++ b/src/Minicute/PrettyPrintable.hs
@@ -31,10 +31,10 @@ prettyPrintList :: (PrettyPrintable a) => PrintSequence -> [a] -> PrintSequence
 prettyPrintList sep = printIntersperse sep . fmap prettyPrint
 {-# INLINEABLE prettyPrintList #-}
 
-instance (PrettyPrintable a, PrettyPrintable (expr a)) => PrettyPrintable (Program_ a expr) where
+instance (PrettyPrintable a, PrettyPrintable (expr a)) => PrettyPrintable (Program_ expr a) where
   prettyPrint (Program_ scs) = prettyPrintList prettyPrintSeparatorWithNewline scs
 
-instance (PrettyPrintable a, PrettyPrintable (expr a)) => PrettyPrintable (Supercombinator_ a expr) where
+instance (PrettyPrintable a, PrettyPrintable (expr a)) => PrettyPrintable (Supercombinator_ expr a) where
   prettyPrint (scId, argBinders, expr)
     = printConcat
       [ prettyPrint scId

--- a/src/Minicute/Transpiler/FreeVariables.hs
+++ b/src/Minicute/Transpiler/FreeVariables.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE RankNTypes #-}
 module Minicute.Transpiler.FreeVariables
   ( ProgramLWithFreeVariables
+  , MainProgramLWithFreeVariables
   , ExpressionLWithFreeVariables
+  , MainExpressionLWithFreeVariables
+
   , FreeVariables
+
   , formFreeVariablesMainL
   , formFreeVariablesL
   ) where
@@ -19,8 +23,10 @@ import Minicute.Types.Minicute.Program
 import qualified Data.Set as Set
 import qualified Data.Set.Lens as Set
 
-type ProgramLWithFreeVariables a = AnnotatedProgramL FreeVariables a
-type ExpressionLWithFreeVariables a = AnnotatedExpressionL FreeVariables a
+type ProgramLWithFreeVariables = AnnotatedProgramL FreeVariables
+type MainProgramLWithFreeVariables = MainAnnotatedProgramL FreeVariables
+type ExpressionLWithFreeVariables = AnnotatedExpressionL FreeVariables
+type MainExpressionLWithFreeVariables = MainAnnotatedExpressionL FreeVariables
 
 type ExpressionWithFreeVariables_ = AnnotatedExpression_ FreeVariables Expression_
 type ExpressionLWithFreeVariables_ = AnnotatedExpression_ FreeVariables ExpressionL_
@@ -30,7 +36,7 @@ type ExpressionLWithFreeVariables_ = AnnotatedExpression_ FreeVariables Expressi
 -- annotated expression
 type FreeVariables = Set.Set Identifier
 
-formFreeVariablesMainL :: MainProgramL -> ProgramLWithFreeVariables Identifier
+formFreeVariablesMainL :: MainProgramL -> MainProgramLWithFreeVariables
 formFreeVariablesMainL = formFreeVariablesL id
 {-# INLINEABLE formFreeVariablesMainL #-}
 

--- a/src/Minicute/Transpiler/LambdaLifting.hs
+++ b/src/Minicute/Transpiler/LambdaLifting.hs
@@ -18,10 +18,10 @@ import qualified Data.Set as Set
 lambdaLifting :: MainProgramL -> MainProgram
 lambdaLifting = liftAnnons . renameVariablesMainL . replaceLambda . formFreeVariablesMainL
 
-replaceLambda :: ProgramLWithFreeVariables Identifier -> MainProgramL
+replaceLambda :: MainProgramLWithFreeVariables -> MainProgramL
 replaceLambda = _supercombinators . each . _supercombinatorBody %~ replaceLambdaEL
 
-replaceLambdaEL :: ExpressionLWithFreeVariables Identifier -> MainExpressionL
+replaceLambdaEL :: MainExpressionLWithFreeVariables -> MainExpressionL
 replaceLambdaEL (AELInteger _ n) = ELInteger n
 replaceLambdaEL (AELConstructor _ tag arity) = ELConstructor tag arity
 replaceLambdaEL (AELVariable _ v) = ELVariable v

--- a/src/Minicute/Transpiler/VariablesRenaming.hs
+++ b/src/Minicute/Transpiler/VariablesRenaming.hs
@@ -27,7 +27,7 @@ renameVariablesL _a
     . renameVariables_ _a (renameVariablesEL _a)
 {-# INLINABLE renameVariablesL #-}
 
-renameVariables_ :: Lens' a Identifier -> Renamer (expr a) -> Renamer (Program_ a expr)
+renameVariables_ :: Lens' a Identifier -> Renamer (expr a) -> Renamer (Program_ expr a)
 renameVariables_ _a rExpr
   = _supercombinators %%~ renameScs
   where

--- a/src/Minicute/Types/Minicute/Expression.hs
+++ b/src/Minicute/Types/Minicute/Expression.hs
@@ -75,6 +75,7 @@ module Minicute.Types.Minicute.Expression
   , AnnotatedExpression_( .. )
 
   , AnnotatedExpression
+  , MainAnnotatedExpression
   , pattern AnnotatedExpression
   , pattern AEInteger
   , pattern AEConstructor
@@ -86,6 +87,7 @@ module Minicute.Types.Minicute.Expression
   , pattern AEMatch
 
   , AnnotatedExpressionL
+  , MainAnnotatedExpressionL
   , pattern AnnotatedExpressionL
   , pattern AELInteger
   , pattern AELConstructor
@@ -273,6 +275,7 @@ newtype AnnotatedExpression_ ann wExpr (expr_ :: * -> *) a
            )
 
 type AnnotatedExpression ann = Fix2 (AnnotatedExpression_ ann Expression_)
+type MainAnnotatedExpression ann = AnnotatedExpression ann Identifier
 pattern AnnotatedExpression ann expr = Fix2 (AnnotatedExpression_ (ann, expr))
 {-# COMPLETE AnnotatedExpression #-}
 pattern AEInteger ann n = AnnotatedExpression ann (EInteger_ n)
@@ -306,6 +309,7 @@ instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedExpression ann a)
       $ showString "AEMatch " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 e . showString " " . showsPrec appPrec1 mcs
 
 type AnnotatedExpressionL ann = Fix2 (AnnotatedExpression_ ann ExpressionL_)
+type MainAnnotatedExpressionL ann = AnnotatedExpressionL ann Identifier
 pattern AnnotatedExpressionL ann expr = Fix2 (AnnotatedExpression_ (ann, expr))
 {-# COMPLETE AnnotatedExpressionL #-}
 pattern AELInteger ann n = AELExpression ann (EInteger_ n)

--- a/src/Minicute/Types/Minicute/Expression.hs
+++ b/src/Minicute/Types/Minicute/Expression.hs
@@ -96,6 +96,7 @@ module Minicute.Types.Minicute.Expression
   , pattern AELLet
   , pattern AELMatch
   , pattern AELLambda
+  , pattern AELExpression
 
   , _annotation
   ) where
@@ -317,9 +318,8 @@ pattern AELLet ann flag lds e = AELExpression ann (ELet_ flag lds e)
 pattern AELMatch ann e mcs = AELExpression ann (EMatch_ e mcs)
 pattern AELLambda ann as e = AnnotatedExpressionL ann (ELLambda_ as e)
 {-# COMPLETE AELInteger, AELConstructor, AELVariable, AELApplication, AELLet, AELMatch, AELLambda #-}
--- |
--- Internal pattern
 pattern AELExpression ann expr = AnnotatedExpressionL ann (ELExpression_ expr)
+{-# COMPLETE AELExpression, AELLambda #-}
 
 instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedExpressionL ann a) where
   showsPrec p (AELInteger ann n)

--- a/src/Minicute/Types/Minicute/Expression.hs
+++ b/src/Minicute/Types/Minicute/Expression.hs
@@ -69,6 +69,7 @@ module Minicute.Types.Minicute.Expression
   , pattern ELLet
   , pattern ELMatch
   , pattern ELLambda
+  , pattern ELExpression
 
 
   , AnnotatedExpression_( .. )
@@ -233,9 +234,8 @@ pattern ELLet flag lds e = ELExpression (ELet_ flag lds e)
 pattern ELMatch e mcs = ELExpression (EMatch_ e mcs)
 pattern ELLambda as e = Fix2 (ELLambda_ as e)
 {-# COMPLETE ELInteger, ELConstructor, ELVariable, ELApplication, ELLet, ELMatch, ELLambda #-}
--- |
--- Internal pattern
 pattern ELExpression e = Fix2 (ELExpression_ e)
+{-# COMPLETE ELExpression, ELLambda #-}
 
 instance {-# OVERLAPS #-} (Show a) => Show (ExpressionL a) where
   showsPrec p (ELInteger n)

--- a/src/Minicute/Types/Minicute/Program.hs
+++ b/src/Minicute/Types/Minicute/Program.hs
@@ -17,8 +17,10 @@ module Minicute.Types.Minicute.Program
   , MainSupercombinatorL
 
   , AnnotatedSupercombinator
+  , MainAnnotatedSupercombinator
 
   , AnnotatedSupercombinatorL
+  , MainAnnotatedSupercombinatorL
 
   , _supercombinatorBinder
   , _supercombinatorArguments
@@ -38,10 +40,12 @@ module Minicute.Types.Minicute.Program
 
 
   , AnnotatedProgram
+  , MainAnnotatedProgram
   , pattern AnnotatedProgram
 
 
   , AnnotatedProgramL
+  , MainAnnotatedProgramL
   , pattern AnnotatedProgramL
 
 
@@ -65,8 +69,10 @@ type SupercombinatorL a = Supercombinator_ ExpressionL a
 type MainSupercombinatorL = SupercombinatorL Identifier
 
 type AnnotatedSupercombinator ann a = Supercombinator_ (AnnotatedExpression ann) a
+type MainAnnotatedSupercombinator ann = AnnotatedSupercombinator ann Identifier
 
 type AnnotatedSupercombinatorL ann a = Supercombinator_ (AnnotatedExpressionL ann) a
+type MainAnnotatedSupercombinatorL ann = AnnotatedSupercombinatorL ann Identifier
 
 _supercombinatorBinder :: Lens' (Supercombinator_ expr a) Identifier
 _supercombinatorBinder = _1
@@ -91,7 +97,7 @@ newtype Program_ expr a
            , Show
            )
 
-type Program a = Program_ Expression a
+type Program = Program_ Expression
 type MainProgram = Program Identifier
 pattern Program sc = Program_ sc
 {-# COMPLETE Program #-}
@@ -100,7 +106,7 @@ instance {-# OVERLAPS #-} (Show a) => Show (Program a) where
   showsPrec = showProgram_ "Program "
 
 
-type ProgramL a = Program_ ExpressionL a
+type ProgramL = Program_ ExpressionL
 type MainProgramL = ProgramL Identifier
 pattern ProgramL sc = Program_ sc
 {-# COMPLETE ProgramL #-}
@@ -109,7 +115,8 @@ instance {-# OVERLAPS #-} (Show a) => Show (ProgramL a) where
   showsPrec = showProgram_ "ProgramL "
 
 
-type AnnotatedProgram ann a = Program_ (AnnotatedExpression ann) a
+type AnnotatedProgram ann = Program_ (AnnotatedExpression ann)
+type MainAnnotatedProgram ann = AnnotatedProgram ann Identifier
 pattern AnnotatedProgram sc = Program_ sc
 {-# COMPLETE AnnotatedProgram #-}
 
@@ -117,7 +124,8 @@ instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedProgram ann a) wh
   showsPrec = showProgram_ "AnnotatedProgram "
 
 
-type AnnotatedProgramL ann a = Program_ (AnnotatedExpressionL ann) a
+type AnnotatedProgramL ann = Program_ (AnnotatedExpressionL ann)
+type MainAnnotatedProgramL ann = AnnotatedProgramL ann Identifier
 pattern AnnotatedProgramL sc = Program_ sc
 {-# COMPLETE AnnotatedProgramL #-}
 

--- a/src/Minicute/Types/Minicute/Program.hs
+++ b/src/Minicute/Types/Minicute/Program.hs
@@ -56,33 +56,33 @@ import GHC.Generics
 import GHC.Show ( appPrec, appPrec1 )
 import Minicute.Types.Minicute.Expression
 
-type Supercombinator_ a expr = (Identifier, [a], expr a)
+type Supercombinator_ expr a = (Identifier, [a], expr a)
 
-type Supercombinator a = Supercombinator_ a Expression
+type Supercombinator a = Supercombinator_ Expression a
 type MainSupercombinator = Supercombinator Identifier
 
-type SupercombinatorL a = Supercombinator_ a ExpressionL
+type SupercombinatorL a = Supercombinator_ ExpressionL a
 type MainSupercombinatorL = SupercombinatorL Identifier
 
-type AnnotatedSupercombinator ann a = Supercombinator_ a (AnnotatedExpression ann)
+type AnnotatedSupercombinator ann a = Supercombinator_ (AnnotatedExpression ann) a
 
-type AnnotatedSupercombinatorL ann a = Supercombinator_ a (AnnotatedExpressionL ann)
+type AnnotatedSupercombinatorL ann a = Supercombinator_ (AnnotatedExpressionL ann) a
 
-_supercombinatorBinder :: Lens' (Supercombinator_ a expr) Identifier
+_supercombinatorBinder :: Lens' (Supercombinator_ expr a) Identifier
 _supercombinatorBinder = _1
 {-# INLINEABLE _supercombinatorBinder #-}
 
-_supercombinatorArguments :: Lens' (Supercombinator_ a expr) [a]
+_supercombinatorArguments :: Lens' (Supercombinator_ expr a) [a]
 _supercombinatorArguments = _2
 {-# INLINEABLE _supercombinatorArguments #-}
 
-_supercombinatorBody :: Lens (Supercombinator_ a expr1) (Supercombinator_ a expr2) (expr1 a) (expr2 a)
+_supercombinatorBody :: Lens (Supercombinator_ expr1 a) (Supercombinator_ expr2 a) (expr1 a) (expr2 a)
 _supercombinatorBody = _3
 {-# INLINEABLE _supercombinatorBody #-}
 
 
-newtype Program_ a expr
-  = Program_ [Supercombinator_ a expr]
+newtype Program_ expr a
+  = Program_ [Supercombinator_ expr a]
   deriving ( Generic
            , Typeable
            , Data
@@ -91,7 +91,7 @@ newtype Program_ a expr
            , Show
            )
 
-type Program a = Program_ a Expression
+type Program a = Program_ Expression a
 type MainProgram = Program Identifier
 pattern Program sc = Program_ sc
 {-# COMPLETE Program #-}
@@ -100,7 +100,7 @@ instance {-# OVERLAPS #-} (Show a) => Show (Program a) where
   showsPrec = showProgram_ "Program "
 
 
-type ProgramL a = Program_ a ExpressionL
+type ProgramL a = Program_ ExpressionL a
 type MainProgramL = ProgramL Identifier
 pattern ProgramL sc = Program_ sc
 {-# COMPLETE ProgramL #-}
@@ -109,7 +109,7 @@ instance {-# OVERLAPS #-} (Show a) => Show (ProgramL a) where
   showsPrec = showProgram_ "ProgramL "
 
 
-type AnnotatedProgram ann a = Program_ a (AnnotatedExpression ann)
+type AnnotatedProgram ann a = Program_ (AnnotatedExpression ann) a
 pattern AnnotatedProgram sc = Program_ sc
 {-# COMPLETE AnnotatedProgram #-}
 
@@ -117,20 +117,20 @@ instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedProgram ann a) wh
   showsPrec = showProgram_ "AnnotatedProgram "
 
 
-type AnnotatedProgramL ann a = Program_ a (AnnotatedExpressionL ann)
+type AnnotatedProgramL ann a = Program_ (AnnotatedExpressionL ann) a
 pattern AnnotatedProgramL sc = Program_ sc
 {-# COMPLETE AnnotatedProgramL #-}
 
 instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedProgramL ann a) where
   showsPrec = showProgram_ "AnnotatedProgramL "
 
-showProgram_ :: (Show a, Show (expr a)) => String -> Int -> Program_ a expr -> ShowS
+showProgram_ :: (Show a, Show (expr a)) => String -> Int -> Program_ expr a -> ShowS
 showProgram_ name p (Program_ scs)
   = showParen (p > appPrec)
     $ showString name . showsPrec appPrec1 scs
 {-# INLINEABLE showProgram_ #-}
 
-_supercombinators :: Lens (Program_ a expr) (Program_ a' expr') [Supercombinator_ a expr] [Supercombinator_ a' expr']
+_supercombinators :: Lens (Program_ expr a) (Program_ expr' a') [Supercombinator_ expr a] [Supercombinator_ expr' a']
 _supercombinators = lens getter setter
   where
     getter (Program_ scs) = scs

--- a/test/Minicute/Parser/ParserSpec.hs
+++ b/test/Minicute/Parser/ParserSpec.hs
@@ -20,14 +20,14 @@ import qualified Minicute.Parser.Parser as P
 
 spec :: Spec
 spec = do
-  describe "programL parser" $ do
-    forM_ testCases (uncurry3 programLTest)
+  describe "mainProgramL parser" $ do
+    forM_ testCases (uncurry3 mainProgramLTest)
 
-programLTest :: TestName -> TestContent -> TestResult -> SpecWith (Arg Expectation)
-programLTest name content (TestSuccess result) = do
+mainProgramLTest :: TestName -> TestContent -> TestResult -> SpecWith (Arg Expectation)
+mainProgramLTest name content (TestSuccess result) = do
   it ("parses " <> name <> " successfully") $ do
     parse P.mainProgramL "" content `shouldParse` result
-programLTest name content (TestFail parseError) = do
+mainProgramLTest name content (TestFail parseError) = do
   it ("fails to parse " <> name) $ do
     parse P.mainProgramL "" content `shouldFailWith` parseError
 

--- a/test/Minicute/Parser/ParserSpec.hs
+++ b/test/Minicute/Parser/ParserSpec.hs
@@ -26,10 +26,10 @@ spec = do
 programLTest :: TestName -> TestContent -> TestResult -> SpecWith (Arg Expectation)
 programLTest name content (TestSuccess result) = do
   it ("parses " <> name <> " successfully") $ do
-    parse P.programL "" content `shouldParse` result
+    parse P.mainProgramL "" content `shouldParse` result
 programLTest name content (TestFail parseError) = do
   it ("fails to parse " <> name) $ do
-    parse P.programL "" content `shouldFailWith` parseError
+    parse P.mainProgramL "" content `shouldFailWith` parseError
 
 type TestName = String
 type TestContent = String

--- a/test/Minicute/PrettyPrintableSpec.hs
+++ b/test/Minicute/PrettyPrintableSpec.hs
@@ -46,81 +46,81 @@ type TestCase = (TestName, TestContent)
 testCases :: [TestCase]
 testCases
   = [ ( "empty program"
-      , [qqCode||]
+      , [qqRawCode||]
       )
     , ( "simple program"
-      , [qqCode|
-               f = 5
+      , [qqRawCode|
+                  f = 5
         |]
       )
     , ( "program with multiple top-level definitions"
-      , [qqCode|
-               f = 5;
-               g = 5
+      , [qqRawCode|
+                  f = 5;
+                  g = 5
         |]
       )
     , ( "program with top-level definitions with arguments"
-      , [qqCode|
-               f x = g x 5;
-               g x y = x y
+      , [qqRawCode|
+                  f x = g x 5;
+                  g x y = x y
         |]
       )
     , ( "program with arithmetic operators"
-      , [qqCode|
-               f = 5 + 4
+      , [qqRawCode|
+                  f = 5 + 4
         |]
       )
     , ( "program with multiple arithmetic operators0"
-      , [qqCode|
-               f = 5 + 4 * 5
+      , [qqRawCode|
+                  f = 5 + 4 * 5
         |]
       )
     , ( "program with multiple arithmetic operators1"
-      , [qqCode|
-               f = (5 + 4) * 5
+      , [qqRawCode|
+                  f = (5 + 4) * 5
         |]
       )
     , ( "program with multiple arithmetic operators2"
-      , [qqCode|
-               f = 5 - 4 - 3
+      , [qqRawCode|
+                  f = 5 - 4 - 3
         |]
       )
     , ( "program with multiple arithmetic operators3"
-      , [qqCode|
-               f = 5 - (4 - 3)
+      , [qqRawCode|
+                  f = 5 - (4 - 3)
         |]
       )
     , ( "program with let"
-      , [qqCode|
-               f = let
-                     x = 5
-                   in
-                     x
+      , [qqRawCode|
+                  f = let
+                        x = 5
+                      in
+                        x
         |]
       )
     , ( "program with match"
-      , [qqCode|
-               f = match x with
-                     <1> -> 1;
-                     <2> -> 2
+      , [qqRawCode|
+                  f = match x with
+                        <1> -> 1;
+                        <2> -> 2
         |]
       )
     , ( "program with lambda"
-      , [qqCode|
-               f = \x ->
-                     x + 4
+      , [qqRawCode|
+                  f = \x ->
+                        x + 4
         |]
       )
     , ( "program with an application with lambda"
-      , [qqCode|
-               f = g (\x ->
-                        x + 4)
+      , [qqRawCode|
+                  f = g (\x ->
+                           x + 4)
         |]
       )
     , ( "program with an application for lambda"
-      , [qqCode|
-               f = (\x ->
-                      x + 4) (5 * 3)
+      , [qqRawCode|
+                  f = (\x ->
+                         x + 4) (5 * 3)
         |]
       )
     ]

--- a/test/Minicute/PrettyPrintableSpec.hs
+++ b/test/Minicute/PrettyPrintableSpec.hs
@@ -27,15 +27,15 @@ programLTest name programString = do
   describe ("with " <> name) $ do
     it "prints re-parsable text" $ do
       program <- parseProgramL programString
-      parse P.programL "" (PS.toString (PP.prettyPrint program)) `shouldParse` program
+      parse P.mainProgramL "" (PS.toString (PP.prettyPrint program)) `shouldParse` program
     it "prints expected text" $ do
       program <- parseProgramL programString
       PS.toString (PP.prettyPrint program) `shouldBe` programString
   where
     parseProgramL :: String -> IO MainProgramL
     parseProgramL ps = do
-      parse P.programL "" ps `shouldSatisfy` isRight
-      case parse P.programL "" ps of
+      parse P.mainProgramL "" ps `shouldSatisfy` isRight
+      case parse P.mainProgramL "" ps of
         Right program -> return program
         Left e -> error (errorBundlePretty e)
 

--- a/test/Minicute/Transpiler/VariablesRenamingSpec.hs
+++ b/test/Minicute/Transpiler/VariablesRenamingSpec.hs
@@ -36,57 +36,57 @@ type TestCase = (TestName, TestBeforeContent, TestAfterContent)
 testCases :: [TestCase]
 testCases
   = [ ( "program with let"
-      , [qqMini|
-               main = f 5 4;
-               f x y = let
-                         g = \z -> x + y + z;
-                         h = \x y -> x * y * g 5
-                       in
-                         h 1 y;
-               g x = x / 2
+      , [qqMiniMainL|
+                    main = f 5 4;
+                    f x y = let
+                              g = \z -> x + y + z;
+                              h = \x y -> x * y * g 5
+                            in
+                              h 1 y;
+                    g x = x / 2
         |]
-      , [qqMini|
-               main = f0 5 4;
-               f0 x2 y3 = let
-                            g4 = \z6 -> x2 + y3 + z6;
-                            h5 = \x7 y8 -> x7 * y8 * g1 5
-                          in
-                            h5 1 y3;
-               g1 x9 = x9 / 2
+      , [qqMiniMainL|
+                    main = f0 5 4;
+                    f0 x2 y3 = let
+                                 g4 = \z6 -> x2 + y3 + z6;
+                                 h5 = \x7 y8 -> x7 * y8 * g1 5
+                               in
+                                 h5 1 y3;
+                    g1 x9 = x9 / 2
         |]
       )
     , ( "program with letrec"
-      , [qqMini|
-               main = f 5 4;
-               f x y = letrec
-                         g = \z -> x + y + z;
-                         h = \x y -> x * y * g 5
-                       in
-                         h 1 y
+      , [qqMiniMainL|
+                    main = f 5 4;
+                    f x y = letrec
+                              g = \z -> x + y + z;
+                              h = \x y -> x * y * g 5
+                            in
+                              h 1 y
         |]
-      , [qqMini|
-               main = f0 5 4;
-               f0 x1 y2 = letrec
-                            g3 = \z5 -> x1 + y2 + z5;
-                            h4 = \x6 y7 -> x6 * y7 * g3 5
-                          in
-                            h4 1 y2
+      , [qqMiniMainL|
+                    main = f0 5 4;
+                    f0 x1 y2 = letrec
+                                 g3 = \z5 -> x1 + y2 + z5;
+                                 h4 = \x6 y7 -> x6 * y7 * g3 5
+                               in
+                                 h4 1 y2
         |]
       )
     , ( "program with match"
-      , [qqMini|
-               main = f (g 5);
-               f x = match x with
-                       <1> -> 0;
-                       <2> h t -> h + f t;
-               g x = if (x > 0) ($C{2;2} x (g (x - 1))) Nil
+      , [qqMiniMainL|
+                    main = f (g 5);
+                    f x = match x with
+                            <1> -> 0;
+                            <2> h t -> h + f t;
+                    g x = if (x > 0) ($C{2;2} x (g (x - 1))) Nil
         |]
-      , [qqMini|
-               main = f0 (g1 5);
-               f0 x2 = match x2 with
-                       <1> -> 0;
-                       <2> h3 t4 -> h3 + f0 t4;
-               g1 x5 = if (x5 > 0) ($C{2;2} x5 (g1 (x5 - 1))) Nil
+      , [qqMiniMainL|
+                    main = f0 (g1 5);
+                    f0 x2 = match x2 with
+                            <1> -> 0;
+                            <2> h3 t4 -> h3 + f0 t4;
+                    g1 x5 = if (x5 > 0) ($C{2;2} x5 (g1 (x5 - 1))) Nil
         |]
       )
     ]

--- a/test/Test/Minicute/Utils.hs
+++ b/test/Test/Minicute/Utils.hs
@@ -10,26 +10,26 @@ import Minicute.Data.String
 import Minicute.Parser.Parser
 import Text.Megaparsec
 
-qqMini :: QuasiQuoter
-qqMini
+qqMiniMainL :: QuasiQuoter
+qqMiniMainL
   = QuasiQuoter
-    { quoteExp = qqMiniExp
-    , quotePat = const . fail $ "qqCode cannot be used as a pattern"
-    , quoteType = const . fail $ "qqCode cannot be used as a type"
-    , quoteDec = const . fail $ "qqCode cannot be used as a declaration"
+    { quoteExp = qqMiniMainLExp
+    , quotePat = const . fail $ "qqMiniMainLExp cannot be used as a pattern"
+    , quoteType = const . fail $ "qqMiniMainLExp cannot be used as a type"
+    , quoteDec = const . fail $ "qqMiniMainLExp cannot be used as a declaration"
     }
 
-qqCode :: QuasiQuoter
-qqCode
+qqRawCode :: QuasiQuoter
+qqRawCode
   = QuasiQuoter
-    { quoteExp = qqCodeExp
-    , quotePat = const . fail $ "qqCode cannot be used as a pattern"
-    , quoteType = const . fail $ "qqCode cannot be used as a type"
-    , quoteDec = const . fail $ "qqCode cannot be used as a declaration"
+    { quoteExp = qqRawCodeExp
+    , quotePat = const . fail $ "qqRawCode cannot be used as a pattern"
+    , quoteType = const . fail $ "qqRawCode cannot be used as a type"
+    , quoteDec = const . fail $ "qqRawCode cannot be used as a declaration"
     }
 
-qqMiniExp :: String -> Q Exp
-qqMiniExp = parseCaseExp . parseExp . qqCodeExp
+qqMiniMainLExp :: String -> Q Exp
+qqMiniMainLExp = parseCaseExp . parseExp . qqRawCodeExp
   where
     parseExp :: Q Exp -> Q Exp
     parseExp e
@@ -41,8 +41,8 @@ qqMiniExp = parseCaseExp . parseExp . qqCodeExp
              Left err -> error (errorBundlePretty err)
         |]
 
-qqCodeExp :: String -> Q Exp
-qqCodeExp = litE . stringL . updateString . toUnix
+qqRawCodeExp :: String -> Q Exp
+qqRawCodeExp = litE . stringL . updateString . toUnix
   where
     updateString = dropEnd 1 . unlines . adjustIndent . trimEndEmptyLines . trimStartEmptyLines . lines
 

--- a/test/Test/Minicute/Utils.hs
+++ b/test/Test/Minicute/Utils.hs
@@ -19,6 +19,15 @@ qqMiniMainL
     , quoteDec = const . fail $ "qqMiniMainLExp cannot be used as a declaration"
     }
 
+qqMiniMain :: QuasiQuoter
+qqMiniMain
+  = QuasiQuoter
+    { quoteExp = qqMiniMainExp
+    , quotePat = const . fail $ "qqMiniMainExp cannot be used as a pattern"
+    , quoteType = const . fail $ "qqMiniMainExp cannot be used as a type"
+    , quoteDec = const . fail $ "qqMiniMainExp cannot be used as a declaration"
+    }
+
 qqRawCode :: QuasiQuoter
 qqRawCode
   = QuasiQuoter
@@ -34,6 +43,19 @@ qqMiniMainLExp = parseCaseExp . parseExp . qqRawCodeExp
     parseExp :: Q Exp -> Q Exp
     parseExp e
       = [| parse mainProgramL "" $(e) |]
+    parseCaseExp :: Q Exp -> Q Exp
+    parseCaseExp e
+      = [| case $(e) of
+             Right result -> result
+             Left err -> error (errorBundlePretty err)
+        |]
+
+qqMiniMainExp :: String -> Q Exp
+qqMiniMainExp = parseCaseExp . parseExp . qqRawCodeExp
+  where
+    parseExp :: Q Exp -> Q Exp
+    parseExp e
+      = [| parse mainProgram "" $(e) |]
     parseCaseExp :: Q Exp -> Q Exp
     parseCaseExp e
       = [| case $(e) of

--- a/test/Test/Minicute/Utils.hs
+++ b/test/Test/Minicute/Utils.hs
@@ -33,7 +33,7 @@ qqMiniExp = parseCaseExp . parseExp . qqCodeExp
   where
     parseExp :: Q Exp -> Q Exp
     parseExp e
-      = [| parse programL "" $(e) |]
+      = [| parse mainProgramL "" $(e) |]
     parseCaseExp :: Q Exp -> Q Exp
     parseCaseExp e
       = [| case $(e) of


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Previous parser was not general enough, so it was hard to make `program` (without lambda) parser.
Moreover, `program` parser did not exist.

**Describe the solution you chose**
Make parser implementation more general, and use them to make a `program` parser.
However, it is still not general enough to implement parsers for annotated program types.
