### PR TITLE
Derive lift instances for types

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -56,6 +56,7 @@ library:
     - megaparsec >= 7.0 && < 8
     - parser-combinators
     - pretty >= 1.1 && < 2
+    - template-haskell >= 2.14 && < 3
 
 # internal-libraries:
 

--- a/src/Minicute/Data/Fix.hs
+++ b/src/Minicute/Data/Fix.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE StandaloneDeriving #-}
 module Minicute.Data.Fix
@@ -15,6 +16,7 @@ import Data.Function
 import GHC.Generics
 import GHC.Read ( lex )
 import GHC.Show ( appPrec, appPrec1 )
+import Language.Haskell.TH.Syntax
 
 newtype Fix f = Fix { unFix :: Fix' f }
   deriving ( Generic
@@ -23,6 +25,7 @@ newtype Fix f = Fix { unFix :: Fix' f }
 type Fix' f = f (Fix f)
 
 deriving instance (Typeable f, Data (f (Fix f))) => Data (Fix f)
+deriving instance (Lift (f (Fix f))) => Lift (Fix f)
 
 instance (Eq (f (Fix f))) => Eq (Fix f) where
   (==) = (==) `on` unFix
@@ -51,6 +54,7 @@ newtype Fix2 f a = Fix2 { unFix2 :: Fix2' f a }
 type Fix2' f a = f (Fix2 f) a
 
 deriving instance (Typeable f, Typeable a, Data (f (Fix2 f) a)) => Data (Fix2 f a)
+deriving instance (Lift (f (Fix2 f) a)) => Lift (Fix2 f a)
 
 instance (Eq (f (Fix2 f) a)) => Eq (Fix2 f a) where
   (==) = (==) `on` unFix2

--- a/src/Minicute/Types/Minicute/Expression.hs
+++ b/src/Minicute/Types/Minicute/Expression.hs
@@ -4,6 +4,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LiberalTypeSynonyms #-}
@@ -112,6 +113,7 @@ import Control.Lens.Type
 import Data.Data
 import GHC.Generics
 import GHC.Show ( appPrec, appPrec1 )
+import Language.Haskell.TH.Syntax
 import Minicute.Data.Fix
 import Minicute.Types.Minicute.Precedence
 import Text.PrettyPrint.HughesPJClass ( Pretty(..) )
@@ -129,6 +131,7 @@ newtype IsRecursive = IsRecursive { isRecursive :: Bool }
   deriving ( Generic
            , Typeable
            , Data
+           , Lift
            , Eq
            , Ord
            )
@@ -209,6 +212,7 @@ data Expression_ expr_ a
   deriving ( Generic
            , Typeable
            , Data
+           , Lift
            , Eq
            , Ord
            , Show
@@ -299,6 +303,7 @@ data ExpressionL_ expr_ a
   deriving ( Generic
            , Typeable
            , Data
+           , Lift
            , Eq
            , Ord
            , Show
@@ -366,6 +371,7 @@ newtype AnnotatedExpression_ ann wExpr (expr_ :: * -> *) a
   deriving ( Generic
            , Typeable
            , Data
+           , Lift
            , Eq
            , Ord
            , Show

--- a/src/Minicute/Types/Minicute/Precedence.hs
+++ b/src/Minicute/Types/Minicute/Precedence.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 module Minicute.Types.Minicute.Precedence where
 
 import Data.Data
 import GHC.Generics
+import Language.Haskell.TH.Syntax
 
 data Precedence
   = PInfixN { precedence :: Int }
@@ -14,6 +16,7 @@ data Precedence
   deriving ( Generic
            , Typeable
            , Data
+           , Lift
            , Eq
            , Ord
            , Show

--- a/src/Minicute/Types/Minicute/Program.hs
+++ b/src/Minicute/Types/Minicute/Program.hs
@@ -4,6 +4,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LiberalTypeSynonyms #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -61,6 +62,7 @@ import Control.Lens.Type
 import Data.Data
 import GHC.Generics
 import GHC.Show ( appPrec, appPrec1 )
+import Language.Haskell.TH.Syntax
 import Minicute.Types.Minicute.Expression
 import Text.PrettyPrint.HughesPJClass ( Pretty(..) )
 
@@ -110,6 +112,7 @@ newtype Program_ expr a
   deriving ( Generic
            , Typeable
            , Data
+           , Lift
            , Eq
            , Ord
            , Show


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
It's hard to optimize quasiquoters without `Lift` instances.

**Describe the solution you chose**
Derive `Lift` instances.
