### PR TITLE
Add fallback caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,16 +34,29 @@ jobs:
     executor: stack-minimal
     steps:
       - checkout
+
       - restore_cache:
-          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-          name: Restore Cached Dependencies
+          name: Restore Global Data
           keys:
-            - cci-demo-haskell-v1-{{ checksum "package.yaml" }}-{{ checksum "stack.yaml" }}
+            - circleci-minicute-global-v1-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+            - circleci-minicute-global-v1-{{ arch }}-{{ checksum "stack.yaml" }}
+            - circleci-minicute-global-v1-{{ arch }}
+
+      - restore_cache:
+          name: Restore Local Data
+          keys:
+            - circleci-minicute-local-v1-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+
       - stack-setup
       - stack-verify-all
+
       - save_cache:
-          name: Cache Dependencies
-          key: cci-demo-haskell-v1-{{ checksum "package.yaml" }}-{{ checksum "stack.yaml" }}
+          name: Cache Global Data
+          key: circleci-minicute-global-v1-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
           paths:
             - "/root/.stack"
+      - save_cache:
+          name: Cache Local Data
+          key: circleci-minicute-local-v1-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+          paths:
             - ".stack-work"


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Resolves #32.
Because of the absence of fallback caches, CircleCI install dependencies again and again even when dependence is changed just a little.

**Describe the solution you chose**
Add fallback caches

**Additional context**
See https://circleci.com/docs/2.0/caching/ for more information