### PR TITLE
Replace type aliases with newtypes

### DIFF
--- a/src/Minicute/Parser/Parser.hs
+++ b/src/Minicute/Parser/Parser.hs
@@ -77,10 +77,12 @@ precedenceTable = return defaultPrecedenceTable
 
 supercombinator_ :: (MonadParser e s m) => WithPrecedence m a -> WithPrecedence m (expr a) -> WithPrecedence m (Supercombinator_ expr a)
 supercombinator_ pA pExpr
-  = (,,)
-    <$> identifier
-    <*> many pA <* L.symbol "="
-    <*> pExpr
+  = Supercombinator_
+    <$> ( (,,)
+          <$> identifier
+          <*> many pA <* L.symbol "="
+          <*> pExpr
+        )
 {-# INLINEABLE supercombinator_ #-}
 
 

--- a/src/Minicute/Parser/Parser.hs
+++ b/src/Minicute/Parser/Parser.hs
@@ -166,10 +166,12 @@ matchExpression_ pA pExpr
 
 matchCase_ :: (MonadParser e s m) => WithPrecedence m a -> WithPrecedence m (expr_ a) -> WithPrecedence m (MatchCase_ expr_ a)
 matchCase_ pA pExpr
-  = (,,)
-    <$> Comb.between (L.symbol "<") (L.symbol ">") L.integer
-    <*> many pA <* L.symbol "->"
-    <*> pExpr
+  = MatchCase_
+    <$> ( (,,)
+          <$> Comb.between (L.symbol "<") (L.symbol ">") L.integer
+          <*> many pA <* L.symbol "->"
+          <*> pExpr
+        )
     <?> "match case"
 {-# INLINEABLE matchCase_ #-}
 

--- a/src/Minicute/Parser/Parser.hs
+++ b/src/Minicute/Parser/Parser.hs
@@ -131,9 +131,11 @@ letExpression_ pA pExpr flag
 
 letDefinition_ :: (MonadParser e s m) => WithPrecedence m a -> WithPrecedence m (expr_ a) -> WithPrecedence m (LetDefinition_ expr_ a)
 letDefinition_ pA pExpr
-  = (,)
-    <$> pA <* L.symbol "="
-    <*> pExpr
+  = LetDefinition_
+    <$> ( (,)
+          <$> pA <* L.symbol "="
+          <*> pExpr
+        )
     <?> "let definition"
 {-# INLINEABLE letDefinition_ #-}
 

--- a/src/Minicute/Transpilers/FreeVariables.hs
+++ b/src/Minicute/Transpilers/FreeVariables.hs
@@ -44,8 +44,8 @@ formFreeVariablesL :: Getter a Identifier -> ProgramL a -> ProgramLWithFreeVaria
 formFreeVariablesL _a
   = _supercombinators . each %~ formFreeVariablesSc
     where
-      formFreeVariablesSc (binder, args, body)
-        = (binder, args, runReader (formFVsEL _a body) $ args ^. setFrom (each . _a))
+      formFreeVariablesSc (SupercombinatorL binder args body)
+        = AnnotatedSupercombinatorL binder args (runReader (formFVsEL _a body) $ args ^. setFrom (each . _a))
 
       {-# INLINEABLE formFreeVariablesSc #-}
 {-# INLINEABLE formFreeVariablesL #-}

--- a/src/Minicute/Transpilers/FreeVariables.hs
+++ b/src/Minicute/Transpilers/FreeVariables.hs
@@ -18,7 +18,7 @@ import Control.Lens.Operators
 import Control.Lens.Type
 import Control.Monad.Reader
 import Minicute.Data.Fix
-import Minicute.Types.Minicute.Program
+import Minicute.Types.Minicute.Annotated.Program
 
 import qualified Data.Set as Set
 import qualified Data.Set.Lens as Set

--- a/src/Minicute/Transpilers/LambdaLifting.hs
+++ b/src/Minicute/Transpilers/LambdaLifting.hs
@@ -7,7 +7,7 @@ import Data.List
 import Data.Tuple
 import Minicute.Transpilers.FreeVariables
 import Minicute.Transpilers.VariablesRenaming
-import Minicute.Types.Minicute.Program
+import Minicute.Types.Minicute.Annotated.Program
 
 import qualified Data.Set as Set
 

--- a/src/Minicute/Transpilers/LambdaLifting.hs
+++ b/src/Minicute/Transpilers/LambdaLifting.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Minicute.Transpilers.LambdaLifting where
 
 import Control.Lens.Each

--- a/src/Minicute/Transpilers/LambdaLifting.hs
+++ b/src/Minicute/Transpilers/LambdaLifting.hs
@@ -49,7 +49,7 @@ liftAnnonsEL (ELApplication e1 e2) = (scs1 <> scs2, EApplication e1' e2')
     (scs1, e1') = liftAnnonsEL e1
     (scs2, e2') = liftAnnonsEL e2
 liftAnnonsEL (ELLet NonRecursive [LetDefinitionL v1 (ELLambda args e)] (ELVariable v2))
-  | v1 == v2 = (pure (v2, args, e') <> scs, EVariable v2)
+  | v1 == v2 = (pure (Supercombinator v2 args e') <> scs, EVariable v2)
   | otherwise = error "liftAnnonsEL: wrong annonymous pattern is created"
   where
     (scs, e') = liftAnnonsEL e

--- a/src/Minicute/Transpilers/LambdaLifting.hs
+++ b/src/Minicute/Transpilers/LambdaLifting.hs
@@ -31,7 +31,7 @@ replaceLambdaEL (AELLet _ flag lDefs expr) = ELLet flag (lDefs & each . _letDefi
 replaceLambdaEL (AELMatch _ expr mCases) = ELMatch (replaceLambdaEL expr) (mCases & each . _matchCaseBody %~ replaceLambdaEL)
 replaceLambdaEL (AELLambda fvs args expr) = foldl' ELApplication annon (ELVariable <$> fvsList)
   where
-    annon = ELLet NonRecursive [("annon", annonBody)] (ELVariable "annon")
+    annon = ELLet NonRecursive [LetDefinitionL "annon" annonBody] (ELVariable "annon")
     annonBody = ELLambda (fvsList <> args) (replaceLambdaEL expr)
     fvsList = Set.toList fvs
 
@@ -48,7 +48,7 @@ liftAnnonsEL (ELApplication e1 e2) = (scs1 <> scs2, EApplication e1' e2')
   where
     (scs1, e1') = liftAnnonsEL e1
     (scs2, e2') = liftAnnonsEL e2
-liftAnnonsEL (ELLet NonRecursive [(v1, ELLambda args e)] (ELVariable v2))
+liftAnnonsEL (ELLet NonRecursive [LetDefinitionL v1 (ELLambda args e)] (ELVariable v2))
   | v1 == v2 = (pure (v2, args, e') <> scs, EVariable v2)
   | otherwise = error "liftAnnonsEL: wrong annonymous pattern is created"
   where

--- a/src/Minicute/Transpilers/VariablesRenaming.hs
+++ b/src/Minicute/Transpilers/VariablesRenaming.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Minicute.Transpilers.VariablesRenaming
@@ -177,8 +178,8 @@ nextIdGeneratorState = (+ 1)
 {-# INLINABLE nextIdGeneratorState #-}
 
 generateId :: Identifier -> State IdGeneratorState Identifier
-generateId identifier = do
+generateId (Identifier n) = do
   st <- get
   put (nextIdGeneratorState st)
-  return (identifier <> show st)
+  return (Identifier (n <> show st))
 {-# INLINABLE generateId #-}

--- a/src/Minicute/Types/Minicute/Annotated/Expression.hs
+++ b/src/Minicute/Types/Minicute/Annotated/Expression.hs
@@ -1,13 +1,9 @@
 {-# OPTIONS_GHC -fno-warn-missing-pattern-synonym-signatures #-}
--- |
--- TODO: remove the following option
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LiberalTypeSynonyms #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 module Minicute.Types.Minicute.Annotated.Expression
@@ -23,6 +19,15 @@ module Minicute.Types.Minicute.Annotated.Expression
   , AnnotatedLetDefinitionL
   , MainAnnotatedLetDefinitionL
   , pattern AnnotatedLetDefinitionL
+
+
+  , AnnotatedMatchCase
+  , MainAnnotatedMatchCase
+  , pattern AnnotatedMatchCase
+
+  , AnnotatedMatchCaseL
+  , MainAnnotatedMatchCaseL
+  , pattern AnnotatedMatchCaseL
 
 
   , AnnotatedExpression_( .. )
@@ -84,6 +89,20 @@ type MainAnnotatedLetDefinitionL ann = AnnotatedLetDefinitionL ann Identifier
 pattern AnnotatedLetDefinitionL :: a -> AnnotatedExpressionL ann a -> AnnotatedLetDefinitionL ann a
 pattern AnnotatedLetDefinitionL a expr = LetDefinition_ (a, expr)
 {-# COMPLETE AnnotatedLetDefinitionL #-}
+
+
+type AnnotatedMatchCase ann a = MatchCase_ (AnnotatedExpression ann) a
+type MainAnnotatedMatchCase ann = AnnotatedMatchCase ann Identifier
+pattern AnnotatedMatchCase :: Int -> [a] -> AnnotatedExpression ann a -> AnnotatedMatchCase ann a
+pattern AnnotatedMatchCase tag argBinders expr = MatchCase_ (tag, argBinders, expr)
+{-# COMPLETE AnnotatedMatchCase #-}
+
+type AnnotatedMatchCaseL ann a = MatchCase_ (AnnotatedExpressionL ann) a
+type MainAnnotatedMatchCaseL ann = AnnotatedMatchCaseL ann Identifier
+pattern AnnotatedMatchCaseL :: Int -> [a] -> AnnotatedExpressionL ann a -> AnnotatedMatchCaseL ann a
+pattern AnnotatedMatchCaseL tag argBinders expr = MatchCase_ (tag, argBinders, expr)
+{-# COMPLETE AnnotatedMatchCaseL #-}
+
 
 newtype AnnotatedExpression_ ann wExpr (expr_ :: * -> *) a
   = AnnotatedExpression_ (ann, wExpr expr_ a)

--- a/src/Minicute/Types/Minicute/Annotated/Expression.hs
+++ b/src/Minicute/Types/Minicute/Annotated/Expression.hs
@@ -1,0 +1,184 @@
+{-# OPTIONS_GHC -fno-warn-missing-pattern-synonym-signatures #-}
+-- |
+-- TODO: remove the following option
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LiberalTypeSynonyms #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+module Minicute.Types.Minicute.Annotated.Expression
+  ( module Minicute.Data.Fix
+  , module Minicute.Types.Minicute.Common
+  , module Minicute.Types.Minicute.Expression
+
+
+  , AnnotatedExpression_( .. )
+
+  , AnnotatedExpression
+  , MainAnnotatedExpression
+  , pattern AnnotatedExpression
+  , pattern AEInteger
+  , pattern AEConstructor
+  , pattern AEVariable
+  , pattern AEVariableIdentifier
+  , pattern AEApplication
+  , pattern AEApplication2
+  , pattern AEApplication3
+  , pattern AELet
+  , pattern AEMatch
+
+  , AnnotatedExpressionL
+  , MainAnnotatedExpressionL
+  , pattern AnnotatedExpressionL
+  , pattern AELInteger
+  , pattern AELConstructor
+  , pattern AELVariable
+  , pattern AELVariableIdentifier
+  , pattern AELApplication
+  , pattern AELApplication2
+  , pattern AELApplication3
+  , pattern AELLet
+  , pattern AELMatch
+  , pattern AELLambda
+  , pattern AELExpression
+
+  , _annotation
+  ) where
+
+import Control.Lens.Lens ( lens )
+import Control.Lens.Type
+import Data.Data
+import Data.Text.Prettyprint.Doc ( Pretty(..) )
+import Data.Text.Prettyprint.Doc.Minicute
+import GHC.Generics
+import GHC.Show ( appPrec, appPrec1 )
+import Language.Haskell.TH.Syntax
+import Minicute.Data.Fix
+import Minicute.Types.Minicute.Common
+import Minicute.Types.Minicute.Expression
+import Minicute.Types.Minicute.Precedence
+
+import qualified Data.Text.Prettyprint.Doc as PP
+
+
+newtype AnnotatedExpression_ ann wExpr (expr_ :: * -> *) a
+  = AnnotatedExpression_ (ann, wExpr expr_ a)
+  deriving ( Generic
+           , Typeable
+           , Data
+           , Lift
+           , Eq
+           , Ord
+           , Show
+           )
+
+type AnnotatedExpression ann = Fix2 (AnnotatedExpression_ ann Expression_)
+type MainAnnotatedExpression ann = AnnotatedExpression ann Identifier
+pattern AnnotatedExpression ann expr = Fix2 (AnnotatedExpression_ (ann, expr))
+{-# COMPLETE AnnotatedExpression #-}
+pattern AEInteger ann n = AnnotatedExpression ann (EInteger_ n)
+pattern AEConstructor ann tag args = AnnotatedExpression ann (EConstructor_ tag args)
+pattern AEVariable ann v = AnnotatedExpression ann (EVariable_ v)
+pattern AEVariableIdentifier ann v = AnnotatedExpression ann (EVariable_ (Identifier v))
+pattern AEApplication ann e1 e2 = AnnotatedExpression ann (EApplication_ e1 e2)
+pattern AEApplication2 ann2 ann1 e1 e2 e3 = AEApplication ann2 (AEApplication ann1 e1 e2) e3
+pattern AEApplication3 ann3 ann2 ann1 e1 e2 e3 e4 = AEApplication ann3 (AEApplication2 ann2 ann1 e1 e2 e3) e4
+pattern AELet ann flag lds e = AnnotatedExpression ann (ELet_ flag lds e)
+pattern AEMatch ann e mcs = AnnotatedExpression ann (EMatch_ e mcs)
+{-# COMPLETE AEInteger, AEConstructor, AEVariable, AEApplication, AELet, AEMatch #-}
+{-# COMPLETE AEInteger, AEConstructor, AEVariableIdentifier, AEApplication, AELet, AEMatch #-}
+
+instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedExpression ann a) where
+  showsPrec p (AEInteger ann n)
+    = showParen (p > appPrec)
+      $ showString "AEInteger " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 n
+  showsPrec p (AEConstructor ann tag args)
+    = showParen (p > appPrec)
+      $ showString "AEConstructor " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 tag . showString " " . showsPrec appPrec1 args
+  showsPrec p (AEVariable ann v)
+    = showParen (p > appPrec)
+      $ showString "AEVariable " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 v
+  showsPrec p (AEApplication ann e1 e2)
+    = showParen (p > appPrec)
+      $ showString "AEApplication " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 e1 . showString " " . showsPrec appPrec1 e2
+  showsPrec p (AELet ann flag lds e)
+    = showParen (p > appPrec)
+      $ showString "AELet " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 flag . showString " " . showsPrec appPrec1 lds . showString " " . showsPrec appPrec1 e
+  showsPrec p (AEMatch ann e mcs)
+    = showParen (p > appPrec)
+      $ showString "AEMatch " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 e . showString " " . showsPrec appPrec1 mcs
+
+instance (Pretty ann, Pretty a, Pretty (wExpr expr_ a)) => Pretty (AnnotatedExpression_ ann wExpr expr_ a) where
+  pretty (AnnotatedExpression_ (ann, expr))
+    = PP.parens (pretty ann PP.<> PP.comma PP.<+> pretty expr)
+
+instance (Pretty ann, Pretty a, Pretty (wExpr expr_ a)) => PrettyPrec (AnnotatedExpression_ ann wExpr expr_ a)
+
+instance (Pretty ann, Pretty a) => Pretty (AnnotatedExpression ann a) where
+  pretty (AEApplication2 ann2 ann1 (AEVariableIdentifier annOp op) e1 e2)
+    | op `elem` fmap fst binaryPrecedenceTable
+    = PP.parens ((PP.hsep . PP.punctuate PP.comma . fmap pretty $ [ann2, ann1, annOp]) PP.<> PP.comma PP.<+> prettyBinaryExpressionPrec 0 op e1 e2)
+  pretty expr = pretty (unFix2 expr)
+
+instance (Pretty ann, Pretty a) => PrettyPrec (AnnotatedExpression ann a)
+
+type AnnotatedExpressionL ann = Fix2 (AnnotatedExpression_ ann ExpressionL_)
+type MainAnnotatedExpressionL ann = AnnotatedExpressionL ann Identifier
+pattern AnnotatedExpressionL ann expr = Fix2 (AnnotatedExpression_ (ann, expr))
+{-# COMPLETE AnnotatedExpressionL #-}
+pattern AELInteger ann n = AELExpression ann (EInteger_ n)
+pattern AELConstructor ann tag args = AELExpression ann (EConstructor_ tag args)
+pattern AELVariable ann v = AELExpression ann (EVariable_ v)
+pattern AELVariableIdentifier ann v = AELExpression ann (EVariable_ (Identifier v))
+pattern AELApplication ann e1 e2 = AELExpression ann (EApplication_ e1 e2)
+pattern AELApplication2 ann2 ann1 e1 e2 e3 = AELApplication ann2 (AELApplication ann1 e1 e2) e3
+pattern AELApplication3 ann3 ann2 ann1 e1 e2 e3 e4 = AELApplication ann3 (AELApplication2 ann2 ann1 e1 e2 e3) e4
+pattern AELLet ann flag lds e = AELExpression ann (ELet_ flag lds e)
+pattern AELMatch ann e mcs = AELExpression ann (EMatch_ e mcs)
+pattern AELLambda ann as e = AnnotatedExpressionL ann (ELLambda_ as e)
+{-# COMPLETE AELInteger, AELConstructor, AELVariable, AELApplication, AELLet, AELMatch, AELLambda #-}
+{-# COMPLETE AELInteger, AELConstructor, AELVariableIdentifier, AELApplication, AELLet, AELMatch, AELLambda #-}
+pattern AELExpression ann expr = AnnotatedExpressionL ann (ELExpression_ expr)
+{-# COMPLETE AELExpression, AELLambda #-}
+
+instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedExpressionL ann a) where
+  showsPrec p (AELInteger ann n)
+    = showParen (p > appPrec)
+      $ showString "AELInteger " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 n
+  showsPrec p (AELConstructor ann tag args)
+    = showParen (p > appPrec)
+      $ showString "AELConstructor " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 tag . showString " " . showsPrec appPrec1 args
+  showsPrec p (AELVariable ann v)
+    = showParen (p > appPrec)
+      $ showString "AELVariable " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 v
+  showsPrec p (AELApplication ann e1 e2)
+    = showParen (p > appPrec)
+      $ showString "AELApplication " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 e1 . showString " " . showsPrec appPrec1 e2
+  showsPrec p (AELLet ann flag lds e)
+    = showParen (p > appPrec)
+      $ showString "AELLet " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 flag . showString " " . showsPrec appPrec1 lds . showString " " . showsPrec appPrec1 e
+  showsPrec p (AELMatch ann e mcs)
+    = showParen (p > appPrec)
+      $ showString "AELMatch " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 e . showString " " . showsPrec appPrec1 mcs
+  showsPrec p (AELLambda ann as e)
+    = showParen (p > appPrec)
+      $ showString "AELLambda " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 as . showString " " . showsPrec appPrec1 e
+
+instance (Pretty ann, Pretty a) => Pretty (AnnotatedExpressionL ann a) where
+  pretty (AELApplication2 ann2 ann1 (AELVariableIdentifier annOp op) e1 e2)
+    | op `elem` fmap fst binaryPrecedenceTable
+    = PP.parens ((PP.hsep . PP.punctuate PP.comma . fmap pretty $ [ann2, ann1, annOp]) PP.<> PP.comma PP.<+> prettyBinaryExpressionPrec 0 op e1 e2)
+  pretty expr = pretty (unFix2 expr)
+
+instance (Pretty ann, Pretty a) => PrettyPrec (AnnotatedExpressionL ann a)
+
+_annotation :: Lens (AnnotatedExpression_ ann wExpr expr_ a) (AnnotatedExpression_ ann' wExpr expr_ a) ann ann'
+_annotation = lens getter setter
+  where
+    getter (AnnotatedExpression_ (ann, _)) = ann
+    setter (AnnotatedExpression_ (_, expr)) ann = AnnotatedExpression_ (ann, expr)
+{-# INLINEABLE _annotation #-}

--- a/src/Minicute/Types/Minicute/Annotated/Expression.hs
+++ b/src/Minicute/Types/Minicute/Annotated/Expression.hs
@@ -16,6 +16,15 @@ module Minicute.Types.Minicute.Annotated.Expression
   , module Minicute.Types.Minicute.Expression
 
 
+  , AnnotatedLetDefinition
+  , MainAnnotatedLetDefinition
+  , pattern AnnotatedLetDefinition
+
+  , AnnotatedLetDefinitionL
+  , MainAnnotatedLetDefinitionL
+  , pattern AnnotatedLetDefinitionL
+
+
   , AnnotatedExpression_( .. )
 
   , AnnotatedExpression
@@ -64,6 +73,17 @@ import Minicute.Types.Minicute.Precedence
 
 import qualified Data.Text.Prettyprint.Doc as PP
 
+type AnnotatedLetDefinition ann a = LetDefinition_ (AnnotatedExpression ann) a
+type MainAnnotatedLetDefinition ann = AnnotatedLetDefinition ann Identifier
+pattern AnnotatedLetDefinition :: a -> AnnotatedExpression ann a -> AnnotatedLetDefinition ann a
+pattern AnnotatedLetDefinition a expr = LetDefinition_ (a, expr)
+{-# COMPLETE AnnotatedLetDefinition #-}
+
+type AnnotatedLetDefinitionL ann a = LetDefinition_ (AnnotatedExpressionL ann) a
+type MainAnnotatedLetDefinitionL ann = AnnotatedLetDefinitionL ann Identifier
+pattern AnnotatedLetDefinitionL :: a -> AnnotatedExpressionL ann a -> AnnotatedLetDefinitionL ann a
+pattern AnnotatedLetDefinitionL a expr = LetDefinition_ (a, expr)
+{-# COMPLETE AnnotatedLetDefinitionL #-}
 
 newtype AnnotatedExpression_ ann wExpr (expr_ :: * -> *) a
   = AnnotatedExpression_ (ann, wExpr expr_ a)

--- a/src/Minicute/Types/Minicute/Annotated/Program.hs
+++ b/src/Minicute/Types/Minicute/Annotated/Program.hs
@@ -3,10 +3,8 @@
 -- TODO: remove the following option
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LiberalTypeSynonyms #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RankNTypes #-}
 module Minicute.Types.Minicute.Annotated.Program
   ( module Minicute.Types.Minicute.Annotated.Expression
   , module Minicute.Types.Minicute.Program
@@ -14,9 +12,11 @@ module Minicute.Types.Minicute.Annotated.Program
 
   , AnnotatedSupercombinator
   , MainAnnotatedSupercombinator
+  , pattern AnnotatedSupercombinator
 
   , AnnotatedSupercombinatorL
   , MainAnnotatedSupercombinatorL
+  , pattern AnnotatedSupercombinatorL
 
 
   , AnnotatedProgram
@@ -35,9 +35,15 @@ import Minicute.Types.Minicute.Program
 
 type AnnotatedSupercombinator ann a = Supercombinator_ (AnnotatedExpression ann) a
 type MainAnnotatedSupercombinator ann = AnnotatedSupercombinator ann Identifier
+pattern AnnotatedSupercombinator :: Identifier -> [a] -> AnnotatedExpression ann a -> AnnotatedSupercombinator ann a
+pattern AnnotatedSupercombinator scId argBinders expr = Supercombinator_ (scId, argBinders, expr)
+{-# COMPLETE AnnotatedSupercombinator #-}
 
 type AnnotatedSupercombinatorL ann a = Supercombinator_ (AnnotatedExpressionL ann) a
 type MainAnnotatedSupercombinatorL ann = AnnotatedSupercombinatorL ann Identifier
+pattern AnnotatedSupercombinatorL :: Identifier -> [a] -> AnnotatedExpressionL ann a -> AnnotatedSupercombinatorL ann a
+pattern AnnotatedSupercombinatorL scId argBinders expr = Supercombinator_ (scId, argBinders, expr)
+{-# COMPLETE AnnotatedSupercombinatorL #-}
 
 
 type AnnotatedProgram ann = Program_ (AnnotatedExpression ann)

--- a/src/Minicute/Types/Minicute/Annotated/Program.hs
+++ b/src/Minicute/Types/Minicute/Annotated/Program.hs
@@ -1,0 +1,60 @@
+{-# OPTIONS_GHC -fno-warn-missing-pattern-synonym-signatures #-}
+-- |
+-- TODO: remove the following option
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LiberalTypeSynonyms #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+module Minicute.Types.Minicute.Annotated.Program
+  ( module Minicute.Types.Minicute.Annotated.Expression
+  , module Minicute.Types.Minicute.Program
+
+
+  , AnnotatedSupercombinator
+  , MainAnnotatedSupercombinator
+
+  , AnnotatedSupercombinatorL
+  , MainAnnotatedSupercombinatorL
+
+
+  , AnnotatedProgram
+  , MainAnnotatedProgram
+  , pattern AnnotatedProgram
+
+
+  , AnnotatedProgramL
+  , MainAnnotatedProgramL
+  , pattern AnnotatedProgramL
+  ) where
+
+import GHC.Show ( appPrec, appPrec1 )
+import Minicute.Types.Minicute.Annotated.Expression
+import Minicute.Types.Minicute.Program
+
+type AnnotatedSupercombinator ann a = Supercombinator_ (AnnotatedExpression ann) a
+type MainAnnotatedSupercombinator ann = AnnotatedSupercombinator ann Identifier
+
+type AnnotatedSupercombinatorL ann a = Supercombinator_ (AnnotatedExpressionL ann) a
+type MainAnnotatedSupercombinatorL ann = AnnotatedSupercombinatorL ann Identifier
+
+
+type AnnotatedProgram ann = Program_ (AnnotatedExpression ann)
+type MainAnnotatedProgram ann = AnnotatedProgram ann Identifier
+pattern AnnotatedProgram sc = Program_ sc
+{-# COMPLETE AnnotatedProgram #-}
+
+instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedProgram ann a) where
+  showsPrec p (Program_ scs)
+    = showParen (p > appPrec) $ showString "AnnotatedProgram " . showsPrec appPrec1 scs
+
+
+type AnnotatedProgramL ann = Program_ (AnnotatedExpressionL ann)
+type MainAnnotatedProgramL ann = AnnotatedProgramL ann Identifier
+pattern AnnotatedProgramL sc = Program_ sc
+{-# COMPLETE AnnotatedProgramL #-}
+
+instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedProgramL ann a) where
+  showsPrec p (Program_ scs)
+    = showParen (p > appPrec) $ showString "AnnotatedProgramL " . showsPrec appPrec1 scs

--- a/src/Minicute/Types/Minicute/Common.hs
+++ b/src/Minicute/Types/Minicute/Common.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE PatternSynonyms #-}
 module Minicute.Types.Minicute.Common
-  ( Identifier
+  ( Identifier( .. )
 
 
   , IsRecursive( .. )
@@ -12,11 +12,29 @@ module Minicute.Types.Minicute.Common
   ) where
 
 import Data.Data
+import Data.String ( IsString(..) )
+import Data.Text.Prettyprint.Doc ( Pretty(..) )
 import GHC.Generics
 import Language.Haskell.TH.Syntax
 
-type Identifier = String
+newtype Identifier
+  = Identifier String
+  deriving ( Generic
+           , Typeable
+           , Data
+           , Lift
+           , Eq
+           , Ord
+           )
 
+instance Show Identifier where
+  showsPrec _ (Identifier v) = showString v
+
+instance IsString Identifier where
+  fromString = Identifier
+
+instance Pretty Identifier where
+  pretty (Identifier v) = pretty v
 
 newtype IsRecursive = IsRecursive { isRecursive :: Bool }
   deriving ( Generic

--- a/src/Minicute/Types/Minicute/Expression.hs
+++ b/src/Minicute/Types/Minicute/Expression.hs
@@ -84,7 +84,6 @@ import Minicute.Types.Minicute.Common
 import Minicute.Types.Minicute.Precedence
 
 import qualified Data.Text.Prettyprint.Doc as PP
-import qualified Data.Set as Set
 
 type LetDefinition_ expr_ a = (a, expr_ a)
 type LetDefinition a = LetDefinition_ Expression a
@@ -329,9 +328,3 @@ instance (Pretty a) => PrettyPrec (ExpressionL a) where
 prettyIndent :: PP.Doc ann -> PP.Doc ann
 prettyIndent = PP.indent 2
 {-# INLINEABLE prettyIndent #-}
-
--- |
--- TODO: move this into a separated module
-instance (Pretty a) => Pretty (Set.Set a) where
-  pretty set
-    = PP.braces (PP.braces (PP.hsep . PP.punctuate PP.comma . fmap pretty . Set.toList $ set))

--- a/src/Minicute/Types/Minicute/Expression.hs
+++ b/src/Minicute/Types/Minicute/Expression.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LiberalTypeSynonyms #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -70,42 +69,8 @@ module Minicute.Types.Minicute.Expression
   , pattern ELMatch
   , pattern ELLambda
   , pattern ELExpression
-
-
-  , AnnotatedExpression_( .. )
-
-  , AnnotatedExpression
-  , MainAnnotatedExpression
-  , pattern AnnotatedExpression
-  , pattern AEInteger
-  , pattern AEConstructor
-  , pattern AEVariable
-  , pattern AEVariableIdentifier
-  , pattern AEApplication
-  , pattern AEApplication2
-  , pattern AEApplication3
-  , pattern AELet
-  , pattern AEMatch
-
-  , AnnotatedExpressionL
-  , MainAnnotatedExpressionL
-  , pattern AnnotatedExpressionL
-  , pattern AELInteger
-  , pattern AELConstructor
-  , pattern AELVariable
-  , pattern AELVariableIdentifier
-  , pattern AELApplication
-  , pattern AELApplication2
-  , pattern AELApplication3
-  , pattern AELLet
-  , pattern AELMatch
-  , pattern AELLambda
-  , pattern AELExpression
-
-  , _annotation
   ) where
 
-import Control.Lens.Lens ( lens )
 import Control.Lens.Tuple
 import Control.Lens.Type
 import Data.Data
@@ -360,124 +325,6 @@ instance (Pretty a) => PrettyPrec (ExpressionL a) where
     = prettyBinaryExpressionPrec p op e1 e2
   prettyPrec p expr = prettyPrec p (unFix2 expr)
 
-
-newtype AnnotatedExpression_ ann wExpr (expr_ :: * -> *) a
-  = AnnotatedExpression_ (ann, wExpr expr_ a)
-  deriving ( Generic
-           , Typeable
-           , Data
-           , Lift
-           , Eq
-           , Ord
-           , Show
-           )
-
-type AnnotatedExpression ann = Fix2 (AnnotatedExpression_ ann Expression_)
-type MainAnnotatedExpression ann = AnnotatedExpression ann Identifier
-pattern AnnotatedExpression ann expr = Fix2 (AnnotatedExpression_ (ann, expr))
-{-# COMPLETE AnnotatedExpression #-}
-pattern AEInteger ann n = AnnotatedExpression ann (EInteger_ n)
-pattern AEConstructor ann tag args = AnnotatedExpression ann (EConstructor_ tag args)
-pattern AEVariable ann v = AnnotatedExpression ann (EVariable_ v)
-pattern AEVariableIdentifier ann v = AnnotatedExpression ann (EVariable_ (Identifier v))
-pattern AEApplication ann e1 e2 = AnnotatedExpression ann (EApplication_ e1 e2)
-pattern AEApplication2 ann2 ann1 e1 e2 e3 = AEApplication ann2 (AEApplication ann1 e1 e2) e3
-pattern AEApplication3 ann3 ann2 ann1 e1 e2 e3 e4 = AEApplication ann3 (AEApplication2 ann2 ann1 e1 e2 e3) e4
-pattern AELet ann flag lds e = AnnotatedExpression ann (ELet_ flag lds e)
-pattern AEMatch ann e mcs = AnnotatedExpression ann (EMatch_ e mcs)
-{-# COMPLETE AEInteger, AEConstructor, AEVariable, AEApplication, AELet, AEMatch #-}
-{-# COMPLETE AEInteger, AEConstructor, AEVariableIdentifier, AEApplication, AELet, AEMatch #-}
-
-instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedExpression ann a) where
-  showsPrec p (AEInteger ann n)
-    = showParen (p > appPrec)
-      $ showString "AEInteger " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 n
-  showsPrec p (AEConstructor ann tag args)
-    = showParen (p > appPrec)
-      $ showString "AEConstructor " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 tag . showString " " . showsPrec appPrec1 args
-  showsPrec p (AEVariable ann v)
-    = showParen (p > appPrec)
-      $ showString "AEVariable " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 v
-  showsPrec p (AEApplication ann e1 e2)
-    = showParen (p > appPrec)
-      $ showString "AEApplication " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 e1 . showString " " . showsPrec appPrec1 e2
-  showsPrec p (AELet ann flag lds e)
-    = showParen (p > appPrec)
-      $ showString "AELet " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 flag . showString " " . showsPrec appPrec1 lds . showString " " . showsPrec appPrec1 e
-  showsPrec p (AEMatch ann e mcs)
-    = showParen (p > appPrec)
-      $ showString "AEMatch " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 e . showString " " . showsPrec appPrec1 mcs
-
-instance (Pretty ann, Pretty a, Pretty (wExpr expr_ a)) => Pretty (AnnotatedExpression_ ann wExpr expr_ a) where
-  pretty (AnnotatedExpression_ (ann, expr))
-    = PP.parens (pretty ann PP.<> PP.comma PP.<+> pretty expr)
-
-instance (Pretty ann, Pretty a, Pretty (wExpr expr_ a)) => PrettyPrec (AnnotatedExpression_ ann wExpr expr_ a)
-
-instance (Pretty ann, Pretty a) => Pretty (AnnotatedExpression ann a) where
-  pretty (AEApplication2 ann2 ann1 (AEVariableIdentifier annOp op) e1 e2)
-    | op `elem` fmap fst binaryPrecedenceTable
-    = PP.parens ((PP.hsep . PP.punctuate PP.comma . fmap pretty $ [ann2, ann1, annOp]) PP.<> PP.comma PP.<+> prettyBinaryExpressionPrec 0 op e1 e2)
-  pretty expr = pretty (unFix2 expr)
-
-instance (Pretty ann, Pretty a) => PrettyPrec (AnnotatedExpression ann a)
-
-type AnnotatedExpressionL ann = Fix2 (AnnotatedExpression_ ann ExpressionL_)
-type MainAnnotatedExpressionL ann = AnnotatedExpressionL ann Identifier
-pattern AnnotatedExpressionL ann expr = Fix2 (AnnotatedExpression_ (ann, expr))
-{-# COMPLETE AnnotatedExpressionL #-}
-pattern AELInteger ann n = AELExpression ann (EInteger_ n)
-pattern AELConstructor ann tag args = AELExpression ann (EConstructor_ tag args)
-pattern AELVariable ann v = AELExpression ann (EVariable_ v)
-pattern AELVariableIdentifier ann v = AELExpression ann (EVariable_ (Identifier v))
-pattern AELApplication ann e1 e2 = AELExpression ann (EApplication_ e1 e2)
-pattern AELApplication2 ann2 ann1 e1 e2 e3 = AELApplication ann2 (AELApplication ann1 e1 e2) e3
-pattern AELApplication3 ann3 ann2 ann1 e1 e2 e3 e4 = AELApplication ann3 (AELApplication2 ann2 ann1 e1 e2 e3) e4
-pattern AELLet ann flag lds e = AELExpression ann (ELet_ flag lds e)
-pattern AELMatch ann e mcs = AELExpression ann (EMatch_ e mcs)
-pattern AELLambda ann as e = AnnotatedExpressionL ann (ELLambda_ as e)
-{-# COMPLETE AELInteger, AELConstructor, AELVariable, AELApplication, AELLet, AELMatch, AELLambda #-}
-{-# COMPLETE AELInteger, AELConstructor, AELVariableIdentifier, AELApplication, AELLet, AELMatch, AELLambda #-}
-pattern AELExpression ann expr = AnnotatedExpressionL ann (ELExpression_ expr)
-{-# COMPLETE AELExpression, AELLambda #-}
-
-instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedExpressionL ann a) where
-  showsPrec p (AELInteger ann n)
-    = showParen (p > appPrec)
-      $ showString "AELInteger " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 n
-  showsPrec p (AELConstructor ann tag args)
-    = showParen (p > appPrec)
-      $ showString "AELConstructor " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 tag . showString " " . showsPrec appPrec1 args
-  showsPrec p (AELVariable ann v)
-    = showParen (p > appPrec)
-      $ showString "AELVariable " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 v
-  showsPrec p (AELApplication ann e1 e2)
-    = showParen (p > appPrec)
-      $ showString "AELApplication " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 e1 . showString " " . showsPrec appPrec1 e2
-  showsPrec p (AELLet ann flag lds e)
-    = showParen (p > appPrec)
-      $ showString "AELLet " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 flag . showString " " . showsPrec appPrec1 lds . showString " " . showsPrec appPrec1 e
-  showsPrec p (AELMatch ann e mcs)
-    = showParen (p > appPrec)
-      $ showString "AELMatch " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 e . showString " " . showsPrec appPrec1 mcs
-  showsPrec p (AELLambda ann as e)
-    = showParen (p > appPrec)
-      $ showString "AELLambda " . showsPrec appPrec1 ann . showString " " . showsPrec appPrec1 as . showString " " . showsPrec appPrec1 e
-
-instance (Pretty ann, Pretty a) => Pretty (AnnotatedExpressionL ann a) where
-  pretty (AELApplication2 ann2 ann1 (AELVariableIdentifier annOp op) e1 e2)
-    | op `elem` fmap fst binaryPrecedenceTable
-    = PP.parens ((PP.hsep . PP.punctuate PP.comma . fmap pretty $ [ann2, ann1, annOp]) PP.<> PP.comma PP.<+> prettyBinaryExpressionPrec 0 op e1 e2)
-  pretty expr = pretty (unFix2 expr)
-
-instance (Pretty ann, Pretty a) => PrettyPrec (AnnotatedExpressionL ann a)
-
-_annotation :: Lens (AnnotatedExpression_ ann wExpr expr_ a) (AnnotatedExpression_ ann' wExpr expr_ a) ann ann'
-_annotation = lens getter setter
-  where
-    getter (AnnotatedExpression_ (ann, _)) = ann
-    setter (AnnotatedExpression_ (_, expr)) ann = AnnotatedExpression_ (ann, expr)
-{-# INLINEABLE _annotation #-}
 
 prettyIndent :: PP.Doc ann -> PP.Doc ann
 prettyIndent = PP.indent 2

--- a/src/Minicute/Types/Minicute/Precedence.hs
+++ b/src/Minicute/Types/Minicute/Precedence.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Minicute.Types.Minicute.Precedence
   ( module Minicute.Types.Minicute.Common
 
@@ -46,7 +47,7 @@ data Precedence
            , Read
            )
 
-type PrecedenceTableEntry = (Identifier, Precedence)
+type PrecedenceTableEntry = (String, Precedence)
 type PrecedenceTable = [PrecedenceTableEntry]
 
 isInfix :: Precedence -> Bool
@@ -86,7 +87,7 @@ miniApplicationPrecedence1 = 101
 {-# INLINEABLE miniApplicationPrecedence1 #-}
 
 
-prettyBinaryExpressionPrec :: (Pretty a, PrettyPrec (expr_ a)) => Int -> Identifier -> expr_ a -> expr_ a -> PP.Doc ann
+prettyBinaryExpressionPrec :: (Pretty a, PrettyPrec (expr_ a)) => Int -> String -> expr_ a -> expr_ a -> PP.Doc ann
 prettyBinaryExpressionPrec p op e1 e2
   = (if p > opP then PP.parens else id) . PP.hsep
     $ [ prettyPrec leftP e1

--- a/src/Minicute/Types/Minicute/Program.hs
+++ b/src/Minicute/Types/Minicute/Program.hs
@@ -21,12 +21,6 @@ module Minicute.Types.Minicute.Program
   , SupercombinatorL
   , MainSupercombinatorL
 
-  , AnnotatedSupercombinator
-  , MainAnnotatedSupercombinator
-
-  , AnnotatedSupercombinatorL
-  , MainAnnotatedSupercombinatorL
-
   , _supercombinatorBinder
   , _supercombinatorArguments
   , _supercombinatorBody
@@ -42,16 +36,6 @@ module Minicute.Types.Minicute.Program
   , ProgramL
   , MainProgramL
   , pattern ProgramL
-
-
-  , AnnotatedProgram
-  , MainAnnotatedProgram
-  , pattern AnnotatedProgram
-
-
-  , AnnotatedProgramL
-  , MainAnnotatedProgramL
-  , pattern AnnotatedProgramL
 
 
   , _supercombinators
@@ -76,12 +60,6 @@ type MainSupercombinator = Supercombinator Identifier
 
 type SupercombinatorL a = Supercombinator_ ExpressionL a
 type MainSupercombinatorL = SupercombinatorL Identifier
-
-type AnnotatedSupercombinator ann a = Supercombinator_ (AnnotatedExpression ann) a
-type MainAnnotatedSupercombinator ann = AnnotatedSupercombinator ann Identifier
-
-type AnnotatedSupercombinatorL ann a = Supercombinator_ (AnnotatedExpressionL ann) a
-type MainAnnotatedSupercombinatorL ann = AnnotatedSupercombinatorL ann Identifier
 
 instance {-# OVERLAPS #-} (Pretty a, Pretty (expr a)) => Pretty (Supercombinator_ expr a) where
   pretty (scId, argBinders, expr)
@@ -127,7 +105,8 @@ pattern Program sc = Program_ sc
 {-# COMPLETE Program #-}
 
 instance {-# OVERLAPS #-} (Show a) => Show (Program a) where
-  showsPrec = showProgram_ "Program "
+  showsPrec p (Program_ scs)
+    = showParen (p > appPrec) $ showString "Program " . showsPrec appPrec1 scs
 
 instance (Pretty a, Pretty (expr a)) => Pretty (Program_ expr a) where
   pretty (Program_ scs) = PP.vcat . PP.punctuate PP.semi . fmap pretty $ scs
@@ -139,31 +118,8 @@ pattern ProgramL sc = Program_ sc
 {-# COMPLETE ProgramL #-}
 
 instance {-# OVERLAPS #-} (Show a) => Show (ProgramL a) where
-  showsPrec = showProgram_ "ProgramL "
-
-
-type AnnotatedProgram ann = Program_ (AnnotatedExpression ann)
-type MainAnnotatedProgram ann = AnnotatedProgram ann Identifier
-pattern AnnotatedProgram sc = Program_ sc
-{-# COMPLETE AnnotatedProgram #-}
-
-instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedProgram ann a) where
-  showsPrec = showProgram_ "AnnotatedProgram "
-
-
-type AnnotatedProgramL ann = Program_ (AnnotatedExpressionL ann)
-type MainAnnotatedProgramL ann = AnnotatedProgramL ann Identifier
-pattern AnnotatedProgramL sc = Program_ sc
-{-# COMPLETE AnnotatedProgramL #-}
-
-instance {-# OVERLAPS #-} (Show ann, Show a) => Show (AnnotatedProgramL ann a) where
-  showsPrec = showProgram_ "AnnotatedProgramL "
-
-showProgram_ :: (Show a, Show (expr a)) => String -> Int -> Program_ expr a -> ShowS
-showProgram_ name p (Program_ scs)
-  = showParen (p > appPrec)
-    $ showString name . showsPrec appPrec1 scs
-{-# INLINEABLE showProgram_ #-}
+  showsPrec p (Program_ scs)
+    = showParen (p > appPrec) $ showString "ProgramL " . showsPrec appPrec1 scs
 
 _supercombinators :: Lens (Program_ expr a) (Program_ expr' a') [Supercombinator_ expr a] [Supercombinator_ expr' a']
 _supercombinators = lens getter setter

--- a/test/Minicute/Parser/LexerSpec.hs
+++ b/test/Minicute/Parser/LexerSpec.hs
@@ -1,6 +1,7 @@
 {- HLINT ignore "Redundant do" -}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 {-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 module Minicute.Parser.LexerSpec
   ( spec

--- a/test/Minicute/Parser/ParserSpec.hs
+++ b/test/Minicute/Parser/ParserSpec.hs
@@ -66,10 +66,10 @@ simpleMainProgramLTestTemplates
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELInteger 1
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELInteger 1)
           ]
         )
       )
@@ -78,10 +78,10 @@ simpleMainProgramLTestTemplates
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELInteger 1
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELInteger 1)
           ]
         )
       )
@@ -90,10 +90,10 @@ simpleMainProgramLTestTemplates
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELInteger 1
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELInteger 1)
           ]
         )
       )
@@ -102,10 +102,10 @@ simpleMainProgramLTestTemplates
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELInteger 1
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELInteger 1)
           ]
         )
       )
@@ -114,10 +114,10 @@ simpleMainProgramLTestTemplates
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELInteger 1
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELInteger 1)
           ]
         )
       )
@@ -127,14 +127,14 @@ simpleMainProgramLTestTemplates
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELInteger 1
-            )
-          , ( "g"
-            , []
-            , ELInteger 2
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELInteger 1)
+          , SupercombinatorL
+            "g"
+            []
+            (ELInteger 2)
           ]
         )
       )
@@ -144,14 +144,14 @@ simpleMainProgramLTestTemplates
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELInteger 1
-            )
-          , ( "g"
-            , []
-            , ELInteger 2
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELInteger 1)
+          , SupercombinatorL
+            "g"
+            []
+            (ELInteger 2)
           ]
         )
       )
@@ -161,14 +161,14 @@ simpleMainProgramLTestTemplates
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELVariable "g"
-            )
-          , ( "g"
-            , []
-            , ELInteger 2
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELVariable "g")
+          , SupercombinatorL
+            "g"
+            []
+            (ELInteger 2)
           ]
         )
       )
@@ -177,10 +177,10 @@ simpleMainProgramLTestTemplates
         |]
       , Right
         ( ProgramL
-          [ ( "matchx"
-            , []
-            , ELVariable "matchx"
-            )
+          [ SupercombinatorL
+            "matchx"
+            []
+            (ELVariable "matchx")
           ]
         )
       )
@@ -224,10 +224,10 @@ arithmeticOperatorMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELApplication2 (ELVariable "+") (ELInteger 1) (ELInteger 1)
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELApplication2 (ELVariable "+") (ELInteger 1) (ELInteger 1))
           ]
         )
       )
@@ -238,14 +238,14 @@ arithmeticOperatorMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELApplication2 (ELVariable "*") (ELInteger 1) (ELVariable "g")
-            )
-          , ( "g"
-            , []
-            , ELInteger 3
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELApplication2 (ELVariable "*") (ELInteger 1) (ELVariable "g"))
+          , SupercombinatorL
+            "g"
+            []
+            (ELInteger 3)
           ]
         )
       )
@@ -255,9 +255,10 @@ arithmeticOperatorMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELApplication2
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELApplication2
               (ELVariable "+")
               (ELInteger 1)
               (ELApplication2 (ELVariable "+") (ELInteger 3) (ELInteger 4))
@@ -271,9 +272,10 @@ arithmeticOperatorMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELApplication2
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELApplication2
               (ELVariable "-")
               (ELApplication2
                (ELVariable "-")
@@ -290,9 +292,10 @@ arithmeticOperatorMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELApplication2
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELApplication2
               (ELVariable "+")
               (ELApplication2
                (ELVariable "*")
@@ -328,14 +331,14 @@ constructorMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELConstructor 1 0
-            )
-          , ( "g"
-            , []
-            , ELConstructor 2 2
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELConstructor 1 0)
+          , SupercombinatorL
+            "g"
+            []
+            (ELConstructor 2 2)
           ]
         )
       )
@@ -346,14 +349,14 @@ constructorMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELApplication (ELConstructor 1 1) (ELInteger 5)
-            )
-          , ( "g"
-            , []
-            , ELApplication (ELConstructor 2 3) (ELVariable "f")
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELApplication (ELConstructor 1 1) (ELInteger 5))
+          , SupercombinatorL
+            "g"
+            []
+            (ELApplication (ELConstructor 2 3) (ELVariable "f"))
           ]
         )
       )
@@ -395,10 +398,10 @@ applicationMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELApplication (ELVariable "g") (ELInteger 5)
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELApplication (ELVariable "g") (ELInteger 5))
           ]
         )
       )
@@ -408,10 +411,10 @@ applicationMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELApplication (ELVariable "g") (ELVariable "f")
-            )
+          [ SupercombinatorL
+            "f"
+            []
+            (ELApplication (ELVariable "g") (ELVariable "f"))
           ]
         )
       )
@@ -432,10 +435,10 @@ supercombinatorMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , ["x"]
-            , ELVariable "x"
-            )
+          [ SupercombinatorL
+            "f"
+            ["x"]
+            (ELVariable "x")
           ]
         )
       )
@@ -445,10 +448,10 @@ supercombinatorMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , ["x", "y"]
-            , ELApplication (ELVariable "x") (ELVariable "y")
-            )
+          [ SupercombinatorL
+            "f"
+            ["x", "y"]
+            (ELApplication (ELVariable "x") (ELVariable "y"))
           ]
         )
       )
@@ -476,9 +479,10 @@ letAndLetrecMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELLet
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELLet
               NonRecursive
               [ LetDefinitionL "x" (ELInteger 5)
               ]
@@ -495,9 +499,10 @@ letAndLetrecMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELLet
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELLet
               Recursive
               [ LetDefinitionL "x" (ELInteger 5)
               ]
@@ -515,9 +520,10 @@ letAndLetrecMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELLet
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELLet
               NonRecursive
               [ LetDefinitionL "x" (ELInteger 5)
               , LetDefinitionL "y" (ELInteger 4)
@@ -537,9 +543,10 @@ letAndLetrecMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELLet
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELLet
               Recursive
               [ LetDefinitionL "x" (ELInteger 5)
               , LetDefinitionL "y" (ELApplication2 (ELVariable "+") (ELVariable "x") (ELVariable "x"))
@@ -560,9 +567,10 @@ letAndLetrecMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELLet
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELLet
               NonRecursive
               [ LetDefinitionL "x" (ELLet NonRecursive [ LetDefinitionL "k" (ELInteger 5) ] (ELVariable "k"))
               ]
@@ -577,9 +585,10 @@ letAndLetrecMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELLet
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELLet
               NonRecursive
               [ LetDefinitionL "x" (ELLet Recursive [ LetDefinitionL "k" (ELInteger 5) ] (ELVariable "k"))
               ]
@@ -594,9 +603,10 @@ letAndLetrecMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELLet
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELLet
               Recursive
               [ LetDefinitionL "x" (ELLet NonRecursive [ LetDefinitionL "k" (ELInteger 5) ] (ELVariable "k"))
               ]
@@ -615,9 +625,10 @@ letAndLetrecMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELLet
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELLet
               Recursive
               [ LetDefinitionL "x" (ELLet Recursive [ LetDefinitionL "k" (ELInteger 5) ] (ELVariable "k"))
               ]
@@ -650,9 +661,10 @@ matchMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELMatch
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELMatch
               (ELConstructor 1 0)
               [ MatchCaseL 1 [] (ELInteger 5)
               ]
@@ -669,9 +681,10 @@ matchMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELMatch
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELMatch
               (ELConstructor 2 0)
               [ MatchCaseL 1 [] (ELInteger 5)
               , MatchCaseL 2 [] (ELInteger 3)
@@ -689,9 +702,10 @@ matchMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELMatch
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELMatch
               (ELApplication2 (ELConstructor 2 2) (ELInteger 5) (ELInteger 4))
               [ MatchCaseL 1 ["x", "y"] (ELVariable "x")
               , MatchCaseL 2 ["a", "b"] (ELVariable "b")
@@ -709,18 +723,19 @@ matchMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELMatch
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELMatch
               (ELApplication2 (ELConstructor 2 2) (ELInteger 5) (ELInteger 4))
               [ MatchCaseL 1 ["x", "y"] (ELVariable "x")
               , MatchCaseL 2 ["a", "b"] (ELVariable "b")
               ]
             )
-          , ( "g"
-            , []
-            , ELInteger 1
-            )
+          , SupercombinatorL
+            "g"
+            []
+            (ELInteger 1)
           ]
         )
       )
@@ -741,9 +756,10 @@ lambdaMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELLambda
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELLambda
               ["x"]
               (ELVariable "x")
             )
@@ -756,9 +772,10 @@ lambdaMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELLambda
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELLambda
               ["x", "y"]
               (ELApplication2 (ELVariable "+") (ELVariable "x") (ELVariable "y"))
             )
@@ -771,9 +788,10 @@ lambdaMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELLambda
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELLambda
               ["x"]
               ( ELLambda
                 ["y"]
@@ -789,9 +807,10 @@ lambdaMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELApplication
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELApplication
               ( ELLambda
                 ["x"]
                 (ELVariable "x")
@@ -825,9 +844,10 @@ complexMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELApplication2
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELApplication2
               (ELVariable "+")
               (ELInteger 5)
               (ELLet NonRecursive [LetDefinitionL "k" (ELInteger 5)] (ELVariable "k"))
@@ -841,9 +861,10 @@ complexMainProgramLTestCases
         |]
       , Right
         ( ProgramL
-          [ ( "f"
-            , []
-            , ELApplication2
+          [ SupercombinatorL
+            "f"
+            []
+            ( ELApplication2
               (ELVariable "+")
               (ELInteger 5)
               (ELMatch (ELConstructor 1 0) [MatchCaseL 1 [] (ELInteger 5)])

--- a/test/Minicute/Parser/ParserSpec.hs
+++ b/test/Minicute/Parser/ParserSpec.hs
@@ -654,7 +654,7 @@ matchMainProgramLTestCases
             , []
             , ELMatch
               (ELConstructor 1 0)
-              [ (1, [], ELInteger 5)
+              [ MatchCaseL 1 [] (ELInteger 5)
               ]
             )
           ]
@@ -673,9 +673,9 @@ matchMainProgramLTestCases
             , []
             , ELMatch
               (ELConstructor 2 0)
-              [ (1, [], ELInteger 5)
-              , (2, [], ELInteger 3)
-              , (4, [], ELVariable "g")
+              [ MatchCaseL 1 [] (ELInteger 5)
+              , MatchCaseL 2 [] (ELInteger 3)
+              , MatchCaseL 4 [] (ELVariable "g")
               ]
             )
           ]
@@ -693,8 +693,8 @@ matchMainProgramLTestCases
             , []
             , ELMatch
               (ELApplication2 (ELConstructor 2 2) (ELInteger 5) (ELInteger 4))
-              [ (1, ["x", "y"], ELVariable "x")
-              , (2, ["a", "b"], ELVariable "b")
+              [ MatchCaseL 1 ["x", "y"] (ELVariable "x")
+              , MatchCaseL 2 ["a", "b"] (ELVariable "b")
               ]
             )
           ]
@@ -713,8 +713,8 @@ matchMainProgramLTestCases
             , []
             , ELMatch
               (ELApplication2 (ELConstructor 2 2) (ELInteger 5) (ELInteger 4))
-              [ (1, ["x", "y"], ELVariable "x")
-              , (2, ["a", "b"], ELVariable "b")
+              [ MatchCaseL 1 ["x", "y"] (ELVariable "x")
+              , MatchCaseL 2 ["a", "b"] (ELVariable "b")
               ]
             )
           , ( "g"
@@ -846,7 +846,7 @@ complexMainProgramLTestCases
             , ELApplication2
               (ELVariable "+")
               (ELInteger 5)
-              (ELMatch (ELConstructor 1 0) [(1, [], ELInteger 5)])
+              (ELMatch (ELConstructor 1 0) [MatchCaseL 1 [] (ELInteger 5)])
             )
           ]
         )

--- a/test/Minicute/Parser/ParserSpec.hs
+++ b/test/Minicute/Parser/ParserSpec.hs
@@ -1,5 +1,6 @@
 {- HLINT ignore "Redundant do" -}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 module Minicute.Parser.ParserSpec
   ( spec

--- a/test/Minicute/Parser/ParserSpec.hs
+++ b/test/Minicute/Parser/ParserSpec.hs
@@ -480,7 +480,7 @@ letAndLetrecMainProgramLTestCases
             , []
             , ELLet
               NonRecursive
-              [ ("x", ELInteger 5)
+              [ LetDefinitionL "x" (ELInteger 5)
               ]
               (ELVariable "x")
             )
@@ -499,7 +499,7 @@ letAndLetrecMainProgramLTestCases
             , []
             , ELLet
               Recursive
-              [ ("x", ELInteger 5)
+              [ LetDefinitionL "x" (ELInteger 5)
               ]
               (ELVariable "x")
             )
@@ -519,8 +519,8 @@ letAndLetrecMainProgramLTestCases
             , []
             , ELLet
               NonRecursive
-              [ ("x", ELInteger 5)
-              , ("y", ELInteger 4)
+              [ LetDefinitionL "x" (ELInteger 5)
+              , LetDefinitionL "y" (ELInteger 4)
               ]
               (ELApplication2 (ELVariable "+") (ELVariable "x") (ELVariable "y"))
             )
@@ -541,9 +541,9 @@ letAndLetrecMainProgramLTestCases
             , []
             , ELLet
               Recursive
-              [ ("x", ELInteger 5)
-              , ("y", ELApplication2 (ELVariable "+") (ELVariable "x") (ELVariable "x"))
-              , ("z", ELApplication2 (ELVariable "*") (ELVariable "x") (ELVariable "y"))
+              [ LetDefinitionL "x" (ELInteger 5)
+              , LetDefinitionL "y" (ELApplication2 (ELVariable "+") (ELVariable "x") (ELVariable "x"))
+              , LetDefinitionL "z" (ELApplication2 (ELVariable "*") (ELVariable "x") (ELVariable "y"))
               ]
               (ELVariable "z")
             )
@@ -564,7 +564,7 @@ letAndLetrecMainProgramLTestCases
             , []
             , ELLet
               NonRecursive
-              [ ("x", ELLet NonRecursive [ ("k", ELInteger 5) ] (ELVariable "k"))
+              [ LetDefinitionL "x" (ELLet NonRecursive [ LetDefinitionL "k" (ELInteger 5) ] (ELVariable "k"))
               ]
               (ELVariable "x")
             )
@@ -581,7 +581,7 @@ letAndLetrecMainProgramLTestCases
             , []
             , ELLet
               NonRecursive
-              [ ("x", ELLet Recursive [ ("k", ELInteger 5) ] (ELVariable "k"))
+              [ LetDefinitionL "x" (ELLet Recursive [ LetDefinitionL "k" (ELInteger 5) ] (ELVariable "k"))
               ]
               (ELVariable "x")
             )
@@ -598,7 +598,7 @@ letAndLetrecMainProgramLTestCases
             , []
             , ELLet
               Recursive
-              [ ("x", ELLet NonRecursive [ ("k", ELInteger 5) ] (ELVariable "k"))
+              [ LetDefinitionL "x" (ELLet NonRecursive [ LetDefinitionL "k" (ELInteger 5) ] (ELVariable "k"))
               ]
               (ELVariable "x")
             )
@@ -619,7 +619,7 @@ letAndLetrecMainProgramLTestCases
             , []
             , ELLet
               Recursive
-              [ ("x", ELLet Recursive [ ("k", ELInteger 5) ] (ELVariable "k"))
+              [ LetDefinitionL "x" (ELLet Recursive [ LetDefinitionL "k" (ELInteger 5) ] (ELVariable "k"))
               ]
               (ELVariable "x")
             )
@@ -830,7 +830,7 @@ complexMainProgramLTestCases
             , ELApplication2
               (ELVariable "+")
               (ELInteger 5)
-              (ELLet NonRecursive [("k", ELInteger 5)] (ELVariable "k"))
+              (ELLet NonRecursive [LetDefinitionL "k" (ELInteger 5)] (ELVariable "k"))
             )
           ]
         )

--- a/test/Minicute/Transpilers/FreeVariablesSpec.hs
+++ b/test/Minicute/Transpilers/FreeVariablesSpec.hs
@@ -1,5 +1,6 @@
 {- HLINT ignore "Redundant do" -}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 module Minicute.Transpilers.FreeVariablesSpec
   ( spec
   ) where
@@ -10,6 +11,7 @@ import Control.Monad
 import Data.Tuple.Extra
 import Minicute.Transpilers.FreeVariables
 import Minicute.Types.Minicute.Annotated.Program
+import Minicute.Utils.TH
 
 import qualified Data.Set as Set
 
@@ -34,44 +36,41 @@ type TestCase = (TestName, TestBeforeContent, TestAfterContent)
 testCases :: [TestCase]
 testCases =
   [ ( "empty program"
-    , ProgramL
-      []
+    , [qqMiniMainL||]
     , AnnotatedProgramL
       []
     )
 
   , ( "program of a top-level definition with a single argument"
-    , ProgramL
-      [ ( "f"
-        , ["x"]
-        , ELApplication2 (ELVariable "+") (ELVariable "x") (ELVariable "x")
-        )
-      ]
+    , [qqMiniMainL|
+                  f x = x + x
+      |]
     , AnnotatedProgramL
-      [ ( "f"
-        , ["x"]
-        , AELApplication2 (Set.singleton "x") (Set.singleton "x") (AELVariable Set.empty "+") (AELVariable (Set.singleton "x") "x") (AELVariable (Set.singleton "x") "x")
+      [ AnnotatedSupercombinatorL
+        "f"
+        ["x"]
+        ( AELApplication2
+          (Set.singleton "x")
+          (Set.singleton "x")
+          (AELVariable Set.empty "+")
+          (AELVariable (Set.singleton "x") "x")
+          (AELVariable (Set.singleton "x") "x")
         )
       ]
     )
 
   , ( "program of a top-level definition of a let expression with a single let definition"
-    , ProgramL
-      [ ( "f"
-        , []
-        , ELLet
-          NonRecursive
-          [ LetDefinitionL
-            "g"
-            (ELApplication (ELVariable "h") (ELInteger 4))
-          ]
-          (ELVariable "g")
-        )
-      ]
+    , [qqMiniMainL|
+                  f = let
+                        g = h 4
+                      in
+                        g
+      |]
     , AnnotatedProgramL
-      [ ( "f"
-        , []
-        , AELLet
+      [ AnnotatedSupercombinatorL
+        "f"
+        []
+        ( AELLet
           Set.empty
           NonRecursive
           [ AnnotatedLetDefinitionL
@@ -84,36 +83,19 @@ testCases =
     )
 
   , ( "program of a top-level definition of a let expression with multiple let definitions"
-    , ProgramL
-      [ ( "f"
-        , []
-        , ELLet
-          NonRecursive
-          [ LetDefinitionL
-            "g1"
-            (ELApplication (ELVariable "h") (ELInteger 4))
-          , LetDefinitionL
-            "g2"
-            (ELApplication (ELVariable "h") (ELInteger 8))
-          , LetDefinitionL
-            "g3"
-            (ELApplication2 (ELVariable "-") (ELInteger 8) (ELInteger 4))
-          ]
-          ( ELApplication2
-            (ELVariable "/")
-            ( ELApplication2
-              (ELVariable "*")
-              (ELVariable "g1")
-              (ELVariable "g2")
-            )
-            (ELVariable "g3")
-          )
-        )
-      ]
+    , [qqMiniMainL|
+                  f = let
+                        g1 = h 4;
+                        g2 = h 8;
+                        g3 = 8 - 4
+                      in
+                        (g1 * g2) / g3
+      |]
     , AnnotatedProgramL
-      [ ( "f"
-        , []
-        , AELLet
+      [ AnnotatedSupercombinatorL
+        "f"
+        []
+        ( AELLet
           Set.empty
           NonRecursive
           [ AnnotatedLetDefinitionL
@@ -144,30 +126,16 @@ testCases =
     )
 
   , ( "program of a top-level definition of a match expression"
-    , ProgramL
-      [ ( "f"
-        , ["x"]
-        , ELMatch
-          (ELVariable "x")
-          [ MatchCaseL
-            1
-            []
-            (ELInteger 4)
-          , MatchCaseL
-            2
-            ["h", "t"]
-            ( ELApplication2
-              (ELVariable "+")
-              (ELVariable "h")
-              (ELApplication (ELVariable "f") (ELVariable "t"))
-            )
-          ]
-        )
-      ]
+    , [qqMiniMainL|
+                  f x = match x with
+                          <1> -> 4;
+                          <2> h t -> h + f t
+      |]
     , AnnotatedProgramL
-      [ ( "f"
-        , ["x"]
-        , AELMatch
+      [ AnnotatedSupercombinatorL
+        "f"
+        ["x"]
+        ( AELMatch
           (Set.singleton "x")
           (AELVariable (Set.singleton "x") "x")
           [ AnnotatedMatchCaseL
@@ -190,16 +158,23 @@ testCases =
     )
 
   , ( "program of a top-level definition of a lambda expression"
-    , ProgramL
-      [ ( "f"
-        , []
-        , ELLambda ["x"] (ELApplication2 (ELVariable "+") (ELInteger 4) (ELVariable "x"))
-        )
-      ]
+    , [qqMiniMainL|
+                  f = \x -> 4 + x
+      |]
     , AnnotatedProgramL
-      [ ( "f"
-        , []
-        , AELLambda Set.empty ["x"] (AELApplication2 (Set.singleton "x") Set.empty (AELVariable Set.empty "+") (AELInteger Set.empty 4) (AELVariable (Set.singleton "x") "x"))
+      [ AnnotatedSupercombinatorL
+        "f"
+        []
+        ( AELLambda
+          Set.empty
+          ["x"]
+          ( AELApplication2
+            (Set.singleton "x")
+            Set.empty
+            (AELVariable Set.empty "+")
+            (AELInteger Set.empty 4)
+            (AELVariable (Set.singleton "x") "x")
+          )
         )
       ]
     )

--- a/test/Minicute/Transpilers/FreeVariablesSpec.hs
+++ b/test/Minicute/Transpilers/FreeVariablesSpec.hs
@@ -1,4 +1,5 @@
 {- HLINT ignore "Redundant do" -}
+{-# LANGUAGE OverloadedStrings #-}
 module Minicute.Transpilers.FreeVariablesSpec
   ( spec
   ) where

--- a/test/Minicute/Transpilers/FreeVariablesSpec.hs
+++ b/test/Minicute/Transpilers/FreeVariablesSpec.hs
@@ -149,13 +149,14 @@ testCases =
         , ["x"]
         , ELMatch
           (ELVariable "x")
-          [ ( 1
-            , []
-            , ELInteger 4
-            )
-          , ( 2
-            , ["h", "t"]
-            , ELApplication2
+          [ MatchCaseL
+            1
+            []
+            (ELInteger 4)
+          , MatchCaseL
+            2
+            ["h", "t"]
+            ( ELApplication2
               (ELVariable "+")
               (ELVariable "h")
               (ELApplication (ELVariable "f") (ELVariable "t"))
@@ -169,13 +170,14 @@ testCases =
         , AELMatch
           (Set.singleton "x")
           (AELVariable (Set.singleton "x") "x")
-          [ ( 1
-            , []
-            , AELInteger Set.empty 4
-            )
-          , ( 2
-            , ["h", "t"]
-            , AELApplication2
+          [ AnnotatedMatchCaseL
+            1
+            []
+            (AELInteger Set.empty 4)
+          , AnnotatedMatchCaseL
+            2
+            ["h", "t"]
+            ( AELApplication2
               (Set.fromList ["h", "t"])
               (Set.singleton "h")
               (AELVariable Set.empty "+")

--- a/test/Minicute/Transpilers/FreeVariablesSpec.hs
+++ b/test/Minicute/Transpilers/FreeVariablesSpec.hs
@@ -61,9 +61,9 @@ testCases =
         , []
         , ELLet
           NonRecursive
-          [ ( "g"
-            , ELApplication (ELVariable "h") (ELInteger 4)
-            )
+          [ LetDefinitionL
+            "g"
+            (ELApplication (ELVariable "h") (ELInteger 4))
           ]
           (ELVariable "g")
         )
@@ -74,9 +74,9 @@ testCases =
         , AELLet
           Set.empty
           NonRecursive
-          [ ( "g"
-            , AELApplication Set.empty (AELVariable Set.empty "h") (AELInteger Set.empty 4)
-            )
+          [ AnnotatedLetDefinitionL
+            "g"
+            (AELApplication Set.empty (AELVariable Set.empty "h") (AELInteger Set.empty 4))
           ]
           (AELVariable (Set.singleton "g") "g")
         )
@@ -89,15 +89,15 @@ testCases =
         , []
         , ELLet
           NonRecursive
-          [ ( "g1"
-            , ELApplication (ELVariable "h") (ELInteger 4)
-            )
-          , ( "g2"
-            , ELApplication (ELVariable "h") (ELInteger 8)
-            )
-          , ( "g3"
-            , ELApplication2 (ELVariable "-") (ELInteger 8) (ELInteger 4)
-            )
+          [ LetDefinitionL
+            "g1"
+            (ELApplication (ELVariable "h") (ELInteger 4))
+          , LetDefinitionL
+            "g2"
+            (ELApplication (ELVariable "h") (ELInteger 8))
+          , LetDefinitionL
+            "g3"
+            (ELApplication2 (ELVariable "-") (ELInteger 8) (ELInteger 4))
           ]
           ( ELApplication2
             (ELVariable "/")
@@ -116,15 +116,15 @@ testCases =
         , AELLet
           Set.empty
           NonRecursive
-          [ ( "g1"
-            , AELApplication Set.empty (AELVariable Set.empty "h") (AELInteger Set.empty 4)
-            )
-          , ( "g2"
-            , AELApplication Set.empty (AELVariable Set.empty "h") (AELInteger Set.empty 8)
-            )
-          , ( "g3"
-            , AELApplication2 Set.empty Set.empty (AELVariable Set.empty "-") (AELInteger Set.empty 8) (AELInteger Set.empty 4)
-            )
+          [ AnnotatedLetDefinitionL
+            "g1"
+            (AELApplication Set.empty (AELVariable Set.empty "h") (AELInteger Set.empty 4))
+          , AnnotatedLetDefinitionL
+            "g2"
+            (AELApplication Set.empty (AELVariable Set.empty "h") (AELInteger Set.empty 8))
+          , AnnotatedLetDefinitionL
+            "g3"
+            (AELApplication2 Set.empty Set.empty (AELVariable Set.empty "-") (AELInteger Set.empty 8) (AELInteger Set.empty 4))
           ]
           ( AELApplication2
             (Set.fromList ["g1", "g2", "g3"])

--- a/test/Minicute/Transpilers/FreeVariablesSpec.hs
+++ b/test/Minicute/Transpilers/FreeVariablesSpec.hs
@@ -9,7 +9,7 @@ import Test.Hspec
 import Control.Monad
 import Data.Tuple.Extra
 import Minicute.Transpilers.FreeVariables
-import Minicute.Types.Minicute.Program
+import Minicute.Types.Minicute.Annotated.Program
 
 import qualified Data.Set as Set
 


### PR DESCRIPTION
**Is your refactoring related to a problem? Please describe.**
Type aliases make modules require options to be compiled without warnings.
More specifically, with type aliases, you should use orphan instances, overlapped instances, 

**Describe the solution you chose**
Replace them with `newtype` definitions.

**Additional context**
Yet there are more `type` definitions to be replaced.
