### PR TITLE
Add a match transpiler

### DIFF
--- a/src/Minicute/Types/GMachine/Instruction.hs
+++ b/src/Minicute/Types/GMachine/Instruction.hs
@@ -190,15 +190,43 @@ data Instruction
   | IPrimitive PrimitiveOperator
 
   {-|
-  Node unwinding operations
+  Node inspecting operations
   -}
   | IUnwind
+  | IDestruct Integer
 
   {-|
   Dump related operations
   -}
   | IEval
   | IReturn
+
+  {-|
+  Match related operations
+  -}
+  | IMatch MatchTable
+  deriving ( Generic
+           , Typeable
+           , Data
+           , Lift
+           , Eq
+           , Ord
+           , Show
+           )
+
+newtype MatchTable
+  = MatchTable [MatchEntry]
+  deriving ( Generic
+           , Typeable
+           , Data
+           , Lift
+           , Eq
+           , Ord
+           , Show
+           )
+
+newtype MatchEntry
+  = MatchEntry (Integer, GMachineExpression)
   deriving ( Generic
            , Typeable
            , Data

--- a/test/Minicute/Types/GMachine/InstructionSpec.hs
+++ b/test/Minicute/Types/GMachine/InstructionSpec.hs
@@ -360,4 +360,63 @@ testCases
                    }
         |]
       )
+
+    , ( "program with a match expression 1"
+      , [qqMiniMain|
+                   f = match $C{1;0} with
+                         <1> -> 0;
+                         <2> h t -> h;
+        |]
+      , [qqGMachine|
+                   f<0> {
+                     MakeConstructor 1 0;
+                     Match {
+                       1 ->
+                         Destruct 0;
+                         PushBasicValue 0;
+                         UpdateAsInteger 0;
+                         Return;
+                       2 ->
+                         Destruct 2;
+                         CopyArgument 0;
+                         Eval;
+                         Update 3;
+                         Pop 3;
+                         Unwind;
+                     };
+                   }
+        |]
+      )
+
+    , ( "program with a match expression 2"
+      , [qqMiniMain|
+                   f = match $C{2;2} 2 $C{1;0} with
+                         <1> -> 0;
+                         <2> h t -> h;
+        |]
+      , [qqGMachine|
+                   f<0> {
+                       MakeConstructor 2 2;
+                       MakeInteger 2;
+                       MakeApplication;
+                     MakeConstructor 1 0;
+                     MakeApplication;
+                     Eval;
+                     Match {
+                       1 ->
+                         Destruct 0;
+                         PushBasicValue 0;
+                         UpdateAsInteger 0;
+                         Return;
+                       2 ->
+                         Destruct 2;
+                         CopyArgument 0;
+                         Eval;
+                         Update 3;
+                         Pop 3;
+                         Unwind;
+                     };
+                   }
+        |]
+      )
     ]


### PR DESCRIPTION
**Resolved Issue(s)**
Resolves #54.

**Describe the solution you chose**
Add a __simple__ match transpiler

**Additional context**
Current one does not work with any complex expressions.
For instance, a match expression in non-strict context cannot be transpiled.