### PR TITLE
Remove deprecated legacy kind

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -48,6 +48,7 @@ library:
     - src
   ghc-options:
     - -Wall
+    - -Wstar-is-type
   dependencies:
     - containers >= 0.6 && < 0.7
     - extra >= 1.6 && < 2

--- a/src/Minicute/Types/Minicute/Annotated/Expression.hs
+++ b/src/Minicute/Types/Minicute/Annotated/Expression.hs
@@ -74,11 +74,12 @@ import Control.Lens.Tuple
 import Control.Lens.Type
 import Control.Lens.Wrapped ( _Wrapped )
 import Data.Data
+import Data.Kind ( Type )
 import Data.Text.Prettyprint.Doc ( Pretty(..) )
 import Data.Text.Prettyprint.Doc.Minicute
 import GHC.Generics
 import GHC.Show ( appPrec, appPrec1 )
-import Language.Haskell.TH.Syntax
+import Language.Haskell.TH.Syntax ( Lift )
 import Minicute.Data.Fix
 import Minicute.Types.Minicute.Common
 import Minicute.Types.Minicute.Expression
@@ -146,7 +147,7 @@ pattern AnnotatedMatchCaseL tag argBinders expr = MatchCase_ (tag, argBinders, e
 -- [@expr_@] a recursive part of the expression.
 --
 -- [@a@] an identifier type of the expression.
-newtype AnnotatedExpression_ ann wExpr (expr_ :: * -> *) a
+newtype AnnotatedExpression_ ann wExpr (expr_ :: Type -> Type) a
   = AnnotatedExpression_ (ann, wExpr expr_ a)
   deriving ( Generic
            , Typeable


### PR DESCRIPTION
**Is your refactoring related to a problem? Please describe.**
`*` as a kind will be deprecated, and [they will remove it eventually](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0030-remove-star-kind.rst).
We use it in a single file only, so it is not a big deal to replace it.

**Describe the solution you chose**
Replace `*` kind with `Data.Kind.Type`.