### PR TITLE
Add simple optimizations

### DIFF
--- a/src/Minicute/Transpilers/Optimizers/ImmediateApplication.hs
+++ b/src/Minicute/Transpilers/Optimizers/ImmediateApplication.hs
@@ -1,0 +1,48 @@
+-- |
+-- Optimizers to remove immediate applications.
+module Minicute.Transpilers.Optimizers.ImmediateApplication
+  ( immediateApplicationMainL
+  ) where
+
+import Control.Lens.Each
+import Control.Lens.Operators
+import Control.Lens.Wrapped ( _Wrapped )
+import Minicute.Data.Minicute.Program
+
+-- |
+-- An optimizer to remove immediate applications in a whole program.
+immediateApplicationMainL :: MainProgramL -> MainProgramL
+immediateApplicationMainL = _Wrapped . each . _supercombinatorBody %~ immediateApplicationMainEL
+
+-- |
+-- An optimizer to remove immediate applications in an expression.
+--
+-- __TODO: use uniplate to remove boilerplate__
+immediateApplicationMainEL :: MainExpressionL -> MainExpressionL
+immediateApplicationMainEL e@(ELInteger _) = e
+immediateApplicationMainEL e@(ELConstructor _ _) = e
+immediateApplicationMainEL e@(ELVariable _) = e
+immediateApplicationMainEL (ELApplication (ELLambda (v : args') expr) e2)
+  | not (null args')
+  = ELLambda args' expr'
+  | otherwise
+  = expr'
+  where
+    expr' = ELLet NonRecursive [LetDefinitionL v e2] (immediateApplicationMainEL expr)
+-- uniplate can make the following case simple.
+-- (Bottom-up way can make the case simple.)
+immediateApplicationMainEL (ELApplication e1 e2)
+  = case e1' of
+      ELLambda _ _ -> immediateApplicationMainEL e'
+      _ -> e'
+  where
+    e' = ELApplication e1' e2'
+
+    e1' = immediateApplicationMainEL e1
+    e2' = immediateApplicationMainEL e2
+immediateApplicationMainEL (ELLet flag lDefs expr)
+  = ELLet flag (lDefs & each . _letDefinitionBody %~ immediateApplicationMainEL) (immediateApplicationMainEL expr)
+immediateApplicationMainEL (ELMatch expr mCases)
+  = ELMatch (immediateApplicationMainEL expr) (mCases & each . _matchCaseBody %~ immediateApplicationMainEL)
+immediateApplicationMainEL (ELLambda args expr)
+  = ELLambda args (immediateApplicationMainEL expr)

--- a/src/Minicute/Transpilers/Optimizers/ImmediateMatch.hs
+++ b/src/Minicute/Transpilers/Optimizers/ImmediateMatch.hs
@@ -1,0 +1,69 @@
+-- |
+-- Optimizers to remove immediate match.
+module Minicute.Transpilers.Optimizers.ImmediateMatch
+  ( immediateMatchMainL
+  ) where
+
+import Control.Lens.Each
+import Control.Lens.Getter ( to )
+import Control.Lens.Operators
+import Control.Lens.Wrapped ( _Wrapped )
+import Data.List
+import Minicute.Data.Minicute.Program
+
+-- |
+-- An optimizer to remove immediate match in a whole program.
+immediateMatchMainL :: MainProgramL -> MainProgramL
+immediateMatchMainL = _Wrapped . each . _supercombinatorBody %~ immediateMatchMainEL
+
+-- |
+-- An optimizer to remove immediate match in an expression.
+--
+-- __TODO: use uniplate to remove boilerplate__
+immediateMatchMainEL :: MainExpressionL -> MainExpressionL
+immediateMatchMainEL e@(ELInteger _) = e
+immediateMatchMainEL e@(ELConstructor _ _) = e
+immediateMatchMainEL e@(ELVariable _) = e
+immediateMatchMainEL (ELApplication e1 e2)
+  = ELApplication (immediateMatchMainEL e1) (immediateMatchMainEL e2)
+immediateMatchMainEL (ELLet flag lDefs (ELMatch (ELVariable v) mCases))
+  | Just vLDef <- lookupLDefsL v lDefs
+  , Just (tag, argExprs) <- destructDataExpression (vLDef ^. _letDefinitionBody)
+  , Just vMCase <- lookupMCasesL tag mCases
+  = let
+      argBinders = vMCase ^. _matchCaseArguments
+      matchLDefs = zipWith LetDefinitionL argBinders argExprs
+
+      innerExpr = immediateMatchMainEL (vMCase ^. _matchCaseBody)
+      expr
+        = if not (null matchLDefs)
+          then ELLet NonRecursive matchLDefs innerExpr
+          else innerExpr
+    in
+      ELLet flag lDefs expr
+immediateMatchMainEL (ELLet flag lDefs expr)
+  = ELLet flag (lDefs & each . _letDefinitionBody %~ immediateMatchMainEL) (immediateMatchMainEL expr)
+immediateMatchMainEL (ELMatch expr mCases)
+  = ELMatch (immediateMatchMainEL expr) (mCases & each . _matchCaseBody %~ immediateMatchMainEL)
+immediateMatchMainEL (ELLambda args expr)
+  = ELLambda args (immediateMatchMainEL expr)
+
+-- |
+-- __TODO: move this into a Util or Data module__
+destructDataExpression :: ExpressionL a -> Maybe (Integer, [ExpressionL a])
+destructDataExpression e = go e []
+  where
+    go (ELConstructor tag arity) args
+      | arity == genericLength args = Just (tag, args)
+    go (ELApplication e1 e2) args = go e1 (e2 : args)
+    go _ _ = Nothing
+
+-- |
+-- __TODO: move this into a Util or Data module__
+lookupMCasesL :: Integer -> [MatchCaseL a] -> Maybe (MatchCaseL a)
+lookupMCasesL tag = find (^. _matchCaseTag . to (== tag))
+
+-- |
+-- __TODO: move this into a Util or Data module__
+lookupLDefsL :: (Eq a) => a -> [LetDefinitionL a] -> Maybe (LetDefinitionL a)
+lookupLDefsL binder = find (^. _letDefinitionBinder . to (== binder))

--- a/src/Minicute/Transpilers/Optimizers/ImmediateMatch.hs
+++ b/src/Minicute/Transpilers/Optimizers/ImmediateMatch.hs
@@ -37,7 +37,7 @@ immediateMatchMainEL (ELLet flag lDefs (ELMatch (ELVariable v) mCases))
       innerExpr = immediateMatchMainEL (vMCase ^. _matchCaseBody)
       expr
         = if not (null matchLDefs)
-          then ELLet NonRecursive matchLDefs innerExpr
+          then immediateMatchMainEL (ELLet NonRecursive matchLDefs innerExpr)
           else innerExpr
     in
       ELLet flag lDefs expr

--- a/src/Minicute/Transpilers/Optimizers/ImmediateMatch.hs
+++ b/src/Minicute/Transpilers/Optimizers/ImmediateMatch.hs
@@ -1,5 +1,5 @@
 -- |
--- Optimizers to remove immediate match.
+-- Optimizers to remove immediate matches.
 module Minicute.Transpilers.Optimizers.ImmediateMatch
   ( immediateMatchMainL
   ) where
@@ -12,12 +12,12 @@ import Data.List
 import Minicute.Data.Minicute.Program
 
 -- |
--- An optimizer to remove immediate match in a whole program.
+-- An optimizer to remove immediate matches in a whole program.
 immediateMatchMainL :: MainProgramL -> MainProgramL
 immediateMatchMainL = _Wrapped . each . _supercombinatorBody %~ immediateMatchMainEL
 
 -- |
--- An optimizer to remove immediate match in an expression.
+-- An optimizer to remove immediate matches in an expression.
 --
 -- __TODO: use uniplate to remove boilerplate__
 immediateMatchMainEL :: MainExpressionL -> MainExpressionL

--- a/src/Minicute/Transpilers/Optimizers/SimpleArithmetic.hs
+++ b/src/Minicute/Transpilers/Optimizers/SimpleArithmetic.hs
@@ -1,0 +1,32 @@
+-- |
+-- Optimizers to reduce simple arithmetic expressions.
+module Minicute.Transpilers.Optimizers.SimpleArithmetic
+  ( simpleArithmeticMainL
+  ) where
+
+import Control.Lens.Each
+import Control.Lens.Operators
+import Control.Lens.Plated ( transformOf )
+import Control.Lens.Wrapped ( _Wrapped )
+import Data.Data.Lens ( uniplate )
+import Minicute.Data.Minicute.Program
+
+-- |
+-- An optimizer to reduce simple arithmetic expressions in a whole program.
+simpleArithmeticMainL :: MainProgramL -> MainProgramL
+simpleArithmeticMainL = _Wrapped . each . _supercombinatorBody %~ simpleArithmeticMainEL
+
+-- |
+-- An optimizer to reduce simple arithmetic expressions in an expression.
+simpleArithmeticMainEL :: MainExpressionL -> MainExpressionL
+simpleArithmeticMainEL = transformOf uniplate go
+  where
+    -- __TODO: replace hard-corded op checking__
+    go (ELApplication2 (ELVariableIdentifier op) (ELInteger n1) (ELInteger n2))
+      | op == "+" = ELInteger (n1 + n2)
+      | op == "-" = ELInteger (n1 - n2)
+      | op == "*" = ELInteger (n1 * n2)
+      -- "/" is not optimized yet... It needs a floating point support
+      --
+      -- __TODO: Add "/" optimization__
+    go e = e

--- a/test/Minicute/Transpilers/Optimizers/ImmediateApplicationSpec.hs
+++ b/test/Minicute/Transpilers/Optimizers/ImmediateApplicationSpec.hs
@@ -1,0 +1,56 @@
+{- HLINT ignore "Redundant do" -}
+{-# LANGUAGE QuasiQuotes #-}
+module Minicute.Transpilers.Optimizers.ImmediateApplicationSpec
+  ( spec
+  ) where
+
+import Test.Hspec
+
+import Control.Monad
+import Data.Tuple.Extra
+import Minicute.Transpilers.Optimizers.ImmediateApplication
+import Minicute.Data.Minicute.Program
+import Minicute.Utils.TH
+
+spec :: Spec
+spec = do
+  describe "immediateApplicationMainL" $ do
+    forM_ testCases (uncurry3 immediateApplicationMainLTest)
+
+immediateApplicationMainLTest :: TestName -> TestBeforeContent -> TestAfterContent -> SpecWith (Arg Expectation)
+immediateApplicationMainLTest name beforeContent afterContent = do
+  it ("immediate applications are optimized in " <> name) $ do
+    immediateApplicationMainL beforeContent `shouldBe` afterContent
+
+type TestName = String
+type TestBeforeContent = MainProgramL
+type TestAfterContent = MainProgramL
+type TestCase = (TestName, TestBeforeContent, TestAfterContent)
+
+testCases :: [TestCase]
+testCases
+  = [ ( "program with an application of a one-argument lambda"
+      , [qqMiniMainL|
+                    f = (\x -> x) 5
+        |]
+      , [qqMiniMainL|
+                    f = let
+                          x = 5
+                        in
+                          x
+        |]
+      )
+
+    , ( "program with an application of a two-argument lambda"
+      , [qqMiniMainL|
+                    f = (\x y -> x + y) 5
+        |]
+      , [qqMiniMainL|
+                    f = \y ->
+                          let
+                            x = 5
+                          in
+                            x + y
+        |]
+      )
+    ]

--- a/test/Minicute/Transpilers/Optimizers/ImmediateMatchSpec.hs
+++ b/test/Minicute/Transpilers/Optimizers/ImmediateMatchSpec.hs
@@ -1,0 +1,67 @@
+{- HLINT ignore "Redundant do" -}
+{-# LANGUAGE QuasiQuotes #-}
+module Minicute.Transpilers.Optimizers.ImmediateMatchSpec
+  ( spec
+  ) where
+
+import Test.Hspec
+
+import Control.Monad
+import Data.Tuple.Extra
+import Minicute.Transpilers.Optimizers.ImmediateMatch
+import Minicute.Data.Minicute.Program
+import Minicute.Utils.TH
+
+spec :: Spec
+spec = do
+  describe "immediateMatchMainL" $ do
+    forM_ testCases (uncurry3 immediateMatchMainLTest)
+
+immediateMatchMainLTest :: TestName -> TestBeforeContent -> TestAfterContent -> SpecWith (Arg Expectation)
+immediateMatchMainLTest name beforeContent afterContent = do
+  it ("immediate matchs are optimized in " <> name) $ do
+    immediateMatchMainL beforeContent `shouldBe` afterContent
+
+type TestName = String
+type TestBeforeContent = MainProgramL
+type TestAfterContent = MainProgramL
+type TestCase = (TestName, TestBeforeContent, TestAfterContent)
+
+testCases :: [TestCase]
+testCases
+  = [ ( "program with a no argument constructor"
+      , [qqMiniMainL|
+                    f = let
+                          x = $C{1;0}
+                        in
+                          match x with
+                            <1> -> 5
+        |]
+      , [qqMiniMainL|
+                    f = let
+                          x = $C{1;0}
+                        in
+                          5
+        |]
+      )
+    , ( "program with a two-argument constructor"
+      , [qqMiniMainL|
+                    f = let
+                          x = $C{2;2} 1 $C{1;0}
+                        in
+                          match x with
+                            <1> -> 5;
+                            <2> h t -> h
+        |]
+      , [qqMiniMainL|
+                    f = let
+                          x = $C{2;2} 1 $C{1;0}
+                        in
+                          let
+                            h = 1;
+                            t = $C{1;0}
+                          in
+                            h
+        |]
+      )
+    ]

--- a/test/Minicute/Transpilers/Optimizers/ImmediateMatchSpec.hs
+++ b/test/Minicute/Transpilers/Optimizers/ImmediateMatchSpec.hs
@@ -44,6 +44,7 @@ testCases
                           5
         |]
       )
+
     , ( "program with a two-argument constructor"
       , [qqMiniMainL|
                     f = let
@@ -52,6 +53,30 @@ testCases
                           match x with
                             <1> -> 5;
                             <2> h t -> h
+        |]
+      , [qqMiniMainL|
+                    f = let
+                          x = $C{2;2} 1 $C{1;0}
+                        in
+                          let
+                            h = 1;
+                            t = $C{1;0}
+                          in
+                            h
+        |]
+      )
+
+    , ( "program with nested optimizable matches"
+      , [qqMiniMainL|
+                    f = let
+                          x = $C{2;2} 1 $C{1;0}
+                        in
+                          match x with
+                            <1> -> 5;
+                            <2> h t ->
+                              match t with
+                                <1> -> h;
+                                <2> th tt -> h + th
         |]
       , [qqMiniMainL|
                     f = let

--- a/test/Minicute/Transpilers/Optimizers/SimpleArithmeticSpec.hs
+++ b/test/Minicute/Transpilers/Optimizers/SimpleArithmeticSpec.hs
@@ -1,0 +1,75 @@
+{- HLINT ignore "Redundant do" -}
+{-# LANGUAGE QuasiQuotes #-}
+module Minicute.Transpilers.Optimizers.SimpleArithmeticSpec
+  ( spec
+  ) where
+
+import Test.Hspec
+
+import Control.Monad
+import Data.Tuple.Extra
+import Minicute.Transpilers.Optimizers.SimpleArithmetic
+import Minicute.Data.Minicute.Program
+import Minicute.Utils.TH
+
+spec :: Spec
+spec = do
+  describe "simpleArithmeticMainL" $ do
+    forM_ testCases (uncurry3 simpleArithmeticMainLTest)
+
+simpleArithmeticMainLTest :: TestName -> TestBeforeContent -> TestAfterContent -> SpecWith (Arg Expectation)
+simpleArithmeticMainLTest name beforeContent afterContent = do
+  it ("immediate applications are optimized in " <> name) $ do
+    simpleArithmeticMainL beforeContent `shouldBe` afterContent
+
+type TestName = String
+type TestBeforeContent = MainProgramL
+type TestAfterContent = MainProgramL
+type TestCase = (TestName, TestBeforeContent, TestAfterContent)
+
+testCases :: [TestCase]
+testCases
+  = [ ( "program with simple arithmetics as top-level bodies"
+      , [qqMiniMainL|
+                    f = 1 + 1;
+                    g = 2 * 3 + 1;
+                    h = (3 - 2) * 3 - 2 * 3 + 3
+        |]
+      , [qqMiniMainL|
+                    f = 2;
+                    g = 7;
+                    h = 0
+        |]
+      )
+
+    , ( "program with simple arithmetics in let definitions"
+      , [qqMiniMainL|
+                    f = let
+                          x = 1 + 2
+                        in
+                          x + 3;
+                    g = let
+                          x = 2 * 3 + 1;
+                          y = let
+                                z = 3 - 2
+                              in
+                                id z
+                        in
+                          test y x (x + x)
+        |]
+      , [qqMiniMainL|
+                    f = let
+                          x = 3
+                        in
+                          x + 3;
+                    g = let
+                          x = 7;
+                          y = let
+                                z = 1
+                              in
+                                id z
+                        in
+                          test y x (x + x)
+        |]
+      )
+    ]


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
There is no optimization step

**Describe the solution you chose**
Add optimizations by program transformation

**Describe alternatives you've considered**
Ad-hoc compiler optimizations

**Additional context**
Currently implemented optimzations
- **Immediate Match Optimzation**
    When let definition whose body is a data value is immediately fed into a match expression, the match expression is redundant and is removable.