### PR TITLE
Fix CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 executors:
   stack-minimal:
     docker:
-      - image: fpco/stack-build-small:lts-13.17
+      - image: fpco/stack-build-small:lts-13.27
 
 commands:
   stack-setup:

--- a/minicute/package.yaml
+++ b/minicute/package.yaml
@@ -79,22 +79,7 @@ tests:
     dependencies:
       - hlint
 
-benchmarks:
-  bench:
-    ### Benchmark fields ###
-    main:                           Bench.hs
-    # other-modules:
-    # generated-other-modules:
-
-    ### Common fields ###
-    source-dirs:
-      - bench
-    ghc-options:
-      - -threaded
-      - -rtsopts
-      - -with-rtsopts=-N
-    dependencies:
-      - minicute
+# benchmarks:
 
 # defaults:
   # github:


### PR DESCRIPTION
**Root of the Bug(s)**
- A wrong dependency package of `minicute:bench` target.
- A docker image of a wrong version for CircleCI

**Previous Behaviour**
CircleCI build failure

**Current Behaviour**
CircleCI build success