### PR TITLE
Add EBNF syntax for miniCUTE and G-machine

### DIFF
--- a/g-machine-syntax/README.md
+++ b/g-machine-syntax/README.md
@@ -8,3 +8,49 @@
 [![GitHub last commit date to master](https://img.shields.io/github/last-commit/CUTE-Lang/miniCUTE/master.svg)](https://github.com/CUTE-Lang/miniCUTE/commits/master)
 
 Types and functions for G-machine syntax.
+
+# EBNF syntax
+
+``` ebnf
+program = { function definition, whitespace };
+
+function definition = identifier, whitespace, "<", integer, ">", whitespace, instructions;
+
+instructions = "{", { instruction, ";", whitespace }, "}";
+instruction = "MakeInteger", integer
+            | "MakeConstructor", integer, integer
+            | "MakeStructure", integer, integer
+            | "MakeApplication",
+            | "MakeGlobal", identifier
+            | "MakePlaceholders", integer
+
+            | "Pop" integer
+            | "Dig" integer
+            | "Update" integer
+            | "Copy" integer
+
+            | "PushBasicValue", integer
+            | "PushExtractedValue"
+            | "WrapAsInteger"
+            | "WrapAsStructure"
+            | "UpdateAsInteger", integer
+            | "UpdateAsStructure", integer
+
+            | "Primitive", primitive operator
+
+            | "Unwind"
+            | "Destruct", integer
+
+            | "Eval"
+            | "Return"
+
+            | "Match", match table;
+
+match table = "{", { match entry }, "}";
+match entry = integer, "->", instructions;
+
+primitive operators = "+"
+                    | "-"
+                    | "*"
+                    | "/"
+```

--- a/g-machine-syntax/package.yaml
+++ b/g-machine-syntax/package.yaml
@@ -7,6 +7,7 @@ description: >
   This package is only for experiment to implement CUTE Lang.
   Do not use this any other purpose. This package would
   introduce breaking changes without any notifications.
+  For EBNF syntax, see <https://github.com/CUTE-Lang/miniCUTE/blob/master/g-machine-syntax/README.md>
 category:                           Language
 ## Practically deprecated
 # stability:

--- a/minicute-syntax/README.md
+++ b/minicute-syntax/README.md
@@ -8,3 +8,60 @@
 [![GitHub last commit date to master](https://img.shields.io/github/last-commit/CUTE-Lang/miniCUTE/master.svg)](https://github.com/CUTE-Lang/miniCUTE/commits/master)
 
 Types and functions for miniCUTE syntax.
+
+# EBNF syntax
+
+Note: `white space`, `identifier`, and `integer` are not defined in the following EBNF definitions.
+
+```ebnf
+program = { top level definition, whitespace };
+
+top level definition = supercombinator; (* other top level definitions will be added in future *)
+
+supercombinator = identifier, whitespace, { identifier, whitespace }, "=", whitespace, expression, ";";
+
+expression = let expression
+           | match expression
+           | lambda expression
+           | precedence expression;
+
+let expression = ( "letrec" | "let" ), whitespace, let definitions, whitespace, "in", whitespace, expression;
+let definitions = let definition, { ";", whitespace, let definition }, ( ";" );
+let definition = identifier, whitespace, "=", whitespace, expression;
+
+match expression = "match", whitespace, expression, whitespace, "with", match cases;
+match cases = match case, { ";", whitespace, match case };
+match case = "<", integer, ">", whitespace, { identifier, whitespace }, "->", whitespace, expression;
+
+lambda expression = "\", identifier, whitespace, { identifier, whitespace }, "->", whitespace, expression;
+
+(* The following non terminals depend on precedence table *)
+precedence expression = precedence 100 expression;
+precedence 100 expression = (* application *) precedence 100 expression, whitespace, precedence 99 expression
+                          | precedence 99 expression;
+precedence 99 expression = precedence 98 expression;
+(*         ...                        ...          *)
+precedence 51 expression = precedence 50 expression;
+precedence 50 expression = (* multiplication *) precedence 50 expression,  "*", precedence 49 expression
+                         | (* division *) precedence 50 expression,  "/", precedence 49 expression
+                         | precedence 49 expression;
+precedence 49 expression = precedence 48 expression;
+(*         ...                        ...          *)
+precedence 41 expression = precedence 40 expression;
+precedence 40 expression = (* addition *) precedence 40 expression,  "+", precedence 39 expression
+                         | (* subtraction *) precedence 40 expression,  "-", precedence 39 expression
+                         | precedence 39 expression;
+precedence 39 expression = precedence 38 expression;
+(*         ...                        ...          *)
+precedence 1 expression = precedence 0 expression;
+precedence 0 expression = atomic expression;
+
+atomic expression = integer expression
+                  | variable expression
+                  | constructor expression
+                  | "(", expression, ")";
+
+integer expression = integer;
+variable expression = identifier;
+constructor expression = "$C{", integer, ";", integer, "}";
+```

--- a/minicute-syntax/package.yaml
+++ b/minicute-syntax/package.yaml
@@ -7,6 +7,7 @@ description: >
   This package is only for experiment to implement CUTE Lang.
   Do not use this any other purpose. This package would
   introduce breaking changes without any notifications.
+  For EBNF syntax, see <https://github.com/CUTE-Lang/miniCUTE/blob/master/minicute-syntax/README.md>
 category:                           Language
 ## Practically deprecated
 # stability:


### PR DESCRIPTION
**Resolved Issue(s)**
Resolves #88.

**Is your feature request related to a problem? Please describe.**
There are no EBNF (or any other formal) syntax for miniCUTE and G-machine for miniCUTE.

**Describe the solution you chose**
Add them as a part of `README.md`s
