### PR TITLE
Update stackage version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,10 @@ commands:
   stack-build-deps:
     description: "Build only dependencies with haskell tool stack."
     steps:
-      - run: stack build --only-dependencies -j2
-      - run: stack test --only-dependencies -j2
-      - run: stack haddock --only-dependencies -j2
+      # Use `-j1` as a memory-safe way.
+      - run: stack build --only-dependencies -j1
+      - run: stack test --only-dependencies -j1
+      - run: stack haddock --only-dependencies -j1
   stack-test-all:
     description: "Test everything related with the haskell codes in this repo with haskell tool stack."
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,32 +166,29 @@ commands:
       - restore_cache:
           name: Restore Global Data
           keys:
-            - circleci-minicute-haskell-global-v4.0-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "hpack-hash.txt" }}
-            - circleci-minicute-haskell-global-v4.0-{{ arch }}-{{ checksum "stack.yaml" }}
-            - circleci-minicute-haskell-global-v4.0-{{ arch }}
+            - circleci-minicute-haskell-global-v5.0-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "hpack-hash.txt" }}
+            - circleci-minicute-haskell-global-v5.0-{{ arch }}-{{ checksum "stack.yaml" }}
+            - circleci-minicute-haskell-global-v5.0-{{ arch }}
+            - circleci-minicute-haskell-global-v5.0
             - circleci-minicute-haskell-global-v4.0
-            - circleci-minicute-haskell-global-v3.3
-            - circleci-minicute-haskell-global-v3.2
-            - circleci-minicute-haskell-global-v3.1
-            - circleci-minicute-haskell-global-v3
 
       - restore_cache:
           name: Restore Project Local Data
           keys:
-            - circleci-minicute-project-local-v4.0-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "hpack-hash.txt" }}
+            - circleci-minicute-project-local-v5.0-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "hpack-hash.txt" }}
 
   save-all-haskell-caches:
     description: "Save all cachable parts of haskell packages."
     steps:
       - save_cache:
           name: Cache Global Data
-          key: circleci-minicute-haskell-global-v4.0-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "hpack-hash.txt" }}
+          key: circleci-minicute-haskell-global-v5.0-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "hpack-hash.txt" }}
           paths:
             - "~/.stack"
 
       - save_cache:
           name: Cache Project Local Data
-          key: circleci-minicute-project-local-v4.0-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "hpack-hash.txt" }}
+          key: circleci-minicute-project-local-v5.0-{{ arch }}-{{ checksum "stack.yaml" }}-{{ checksum "hpack-hash.txt" }}
           paths:
             - ".stack-work"
 
@@ -201,15 +198,14 @@ commands:
       - restore_cache:
           name: Restore Global Data
           keys:
+            - circleci-minicute-node-global-v5.0
             - circleci-minicute-node-global-v4.0
-            - circleci-minicute-node-global-v4.0
-            - circleci-minicute-node-global-v3
 
   save-all-node-caches:
     description: "Save all cachable parts of node packages."
     steps:
       - save_cache:
           name: Cache Global Data
-          key: circleci-minicute-node-global-v4.0
+          key: circleci-minicute-node-global-v5.0
           paths:
             - "~/.npm"

--- a/extensions/base/lib/Data/Tuple/Minicute.hs
+++ b/extensions/base/lib/Data/Tuple/Minicute.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 -- |

--- a/hlint.yaml
+++ b/hlint.yaml
@@ -8,7 +8,6 @@
 # enabled rules
 - warn: {name: "Use module export list"}
 - warn: {name: "Use explicit module export list"}
-- warn: {name: "Use DerivingStrategies"}
 
 - group:
     name: generalise

--- a/main-packages/g-machine-interpreter/lib/Minicute/Interpreter/GMachine.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Interpreter/GMachine.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 module Minicute.Interpreter.GMachine
   ( module Minicute.Control.GMachine
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.27
+resolver: lts-14.7
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -50,9 +50,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
-extra-deps:
-- llvm-hs-8.0.0
-- llvm-hs-pure-8.0.0
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags:


### PR DESCRIPTION
**Resolved Issue(s)**
Resolves #90.

**Is your refactoring related to a problem? Please describe.**
`llvm-hs-pure` library is built again every time CI runs.

**Describe the solution you chose**
Update stackage to remove llvm-hs-pure from `extra-deps`.

**Describe alternatives you've considered**
Building an internal library for LLVM would be one solution. However, it will take a lot of time, so I defer it until other problems occur.