### PR TITLE
Add hlint-run preprocessor

### DIFF
--- a/extensions/base/hlint/Main.hs
+++ b/extensions/base/hlint/Main.hs
@@ -1,16 +1,2 @@
-module Main
-  ( main
-  ) where
-
-import Language.Haskell.HLint.Minicute ( hlint )
-import System.Exit ( exitFailure, exitSuccess )
-
-main :: IO ()
-main =
-  do
-    -- This 'putStrLn' is to format stack test output
-    putStrLn ""
-    hints <- hlint ["lib"]
-    if null hints
-    then exitSuccess
-    else exitFailure
+{-# OPTIONS_GHC -F -pgmF hlint-run #-}
+{-# OPTIONS_GHC -optF lib #-}

--- a/extensions/prettyprinter/hlint/Main.hs
+++ b/extensions/prettyprinter/hlint/Main.hs
@@ -1,16 +1,2 @@
-module Main
-  ( main
-  ) where
-
-import Language.Haskell.HLint.Minicute ( hlint )
-import System.Exit ( exitFailure, exitSuccess )
-
-main :: IO ()
-main =
-  do
-    -- This 'putStrLn' is to format stack test output
-    putStrLn ""
-    hints <- hlint ["lib"]
-    if null hints
-    then exitSuccess
-    else exitFailure
+{-# OPTIONS_GHC -F -pgmF hlint-run #-}
+{-# OPTIONS_GHC -optF lib #-}

--- a/main-packages/common-syntax/hlint/Main.hs
+++ b/main-packages/common-syntax/hlint/Main.hs
@@ -1,16 +1,3 @@
-module Main
-  ( main
-  ) where
-
-import Language.Haskell.HLint.Minicute ( hlint )
-import System.Exit ( exitFailure, exitSuccess )
-
-main :: IO ()
-main =
-  do
-    -- This 'putStrLn' is to format stack test output
-    putStrLn ""
-    hints <- hlint ["lib", "test"]
-    if null hints
-    then exitSuccess
-    else exitFailure
+{-# OPTIONS_GHC -F -pgmF hlint-run #-}
+{-# OPTIONS_GHC -optF lib #-}
+{-# OPTIONS_GHC -optF test #-}

--- a/main-packages/g-machine-interpreter/hlint/Main.hs
+++ b/main-packages/g-machine-interpreter/hlint/Main.hs
@@ -1,16 +1,4 @@
-module Main
-  ( main
-  ) where
-
-import Language.Haskell.HLint.Minicute ( hlint )
-import System.Exit ( exitFailure, exitSuccess )
-
-main :: IO ()
-main =
-  do
-    -- This 'putStrLn' is to format stack test output
-    putStrLn ""
-    hints <- hlint ["minicute-g", "lib", "test"]
-    if null hints
-    then exitSuccess
-    else exitFailure
+{-# OPTIONS_GHC -F -pgmF hlint-run #-}
+{-# OPTIONS_GHC -optF lib #-}
+{-# OPTIONS_GHC -optF test #-}
+{-# OPTIONS_GHC -optF minicute-g #-}

--- a/main-packages/g-machine-syntax/hlint/Main.hs
+++ b/main-packages/g-machine-syntax/hlint/Main.hs
@@ -1,16 +1,3 @@
-module Main
-  ( main
-  ) where
-
-import Language.Haskell.HLint.Minicute ( hlint )
-import System.Exit ( exitFailure, exitSuccess )
-
-main :: IO ()
-main =
-  do
-    -- This 'putStrLn' is to format stack test output
-    putStrLn ""
-    hints <- hlint ["lib", "test"]
-    if null hints
-    then exitSuccess
-    else exitFailure
+{-# OPTIONS_GHC -F -pgmF hlint-run #-}
+{-# OPTIONS_GHC -optF lib #-}
+{-# OPTIONS_GHC -optF test #-}

--- a/main-packages/g-machinizer/hlint/Main.hs
+++ b/main-packages/g-machinizer/hlint/Main.hs
@@ -1,16 +1,3 @@
-module Main
-  ( main
-  ) where
-
-import Language.Haskell.HLint.Minicute ( hlint )
-import System.Exit ( exitFailure, exitSuccess )
-
-main :: IO ()
-main =
-  do
-    -- This 'putStrLn' is to format stack test output
-    putStrLn ""
-    hints <- hlint ["lib", "test"]
-    if null hints
-    then exitSuccess
-    else exitFailure
+{-# OPTIONS_GHC -F -pgmF hlint-run #-}
+{-# OPTIONS_GHC -optF lib #-}
+{-# OPTIONS_GHC -optF test #-}

--- a/main-packages/llvm-generator/hlint/Main.hs
+++ b/main-packages/llvm-generator/hlint/Main.hs
@@ -1,16 +1,3 @@
-module Main
-  ( main
-  ) where
-
-import Language.Haskell.HLint.Minicute ( hlint )
-import System.Exit ( exitFailure, exitSuccess )
-
-main :: IO ()
-main =
-  do
-    -- This 'putStrLn' is to format stack test output
-    putStrLn ""
-    hints <- hlint ["lib", "test"]
-    if null hints
-    then exitSuccess
-    else exitFailure
+{-# OPTIONS_GHC -F -pgmF hlint-run #-}
+{-# OPTIONS_GHC -optF lib #-}
+{-# OPTIONS_GHC -optF test #-}

--- a/main-packages/minicute-compiler/hlint/Main.hs
+++ b/main-packages/minicute-compiler/hlint/Main.hs
@@ -1,16 +1,2 @@
-module Main
-  ( main
-  ) where
-
-import Language.Haskell.HLint.Minicute ( hlint )
-import System.Exit ( exitFailure, exitSuccess )
-
-main :: IO ()
-main =
-  do
-    -- This 'putStrLn' is to format stack test output
-    putStrLn ""
-    hints <- hlint ["minicute"]
-    if null hints
-    then exitSuccess
-    else exitFailure
+{-# OPTIONS_GHC -F -pgmF hlint-run #-}
+{-# OPTIONS_GHC -optF minicute #-}

--- a/main-packages/minicute-optimizer/hlint/Main.hs
+++ b/main-packages/minicute-optimizer/hlint/Main.hs
@@ -1,16 +1,3 @@
-module Main
-  ( main
-  ) where
-
-import Language.Haskell.HLint.Minicute ( hlint )
-import System.Exit ( exitFailure, exitSuccess )
-
-main :: IO ()
-main =
-  do
-    -- This 'putStrLn' is to format stack test output
-    putStrLn ""
-    hints <- hlint ["lib", "test"]
-    if null hints
-    then exitSuccess
-    else exitFailure
+{-# OPTIONS_GHC -F -pgmF hlint-run #-}
+{-# OPTIONS_GHC -optF lib #-}
+{-# OPTIONS_GHC -optF test #-}

--- a/main-packages/minicute-syntax/hlint/Main.hs
+++ b/main-packages/minicute-syntax/hlint/Main.hs
@@ -1,16 +1,3 @@
-module Main
-  ( main
-  ) where
-
-import Language.Haskell.HLint.Minicute ( hlint )
-import System.Exit ( exitFailure, exitSuccess )
-
-main :: IO ()
-main =
-  do
-    -- This 'putStrLn' is to format stack test output
-    putStrLn ""
-    hints <- hlint ["lib", "test"]
-    if null hints
-    then exitSuccess
-    else exitFailure
+{-# OPTIONS_GHC -F -pgmF hlint-run #-}
+{-# OPTIONS_GHC -optF lib #-}
+{-# OPTIONS_GHC -optF test #-}

--- a/utilities/hlint/hlint-run/Main.hs
+++ b/utilities/hlint/hlint-run/Main.hs
@@ -1,0 +1,22 @@
+module Main
+  ( main
+  ) where
+
+import System.Environment
+
+main :: IO ()
+main = do
+  _ : _ : dst : args <- getArgs
+  writeFile dst (makeMainFile args)
+
+makeMainFile :: [String] -> String
+makeMainFile args =
+  ( showString "module Main\n"
+  . showString "  ( main\n"
+  . showString "  ) where\n"
+  . showString "\n"
+  . showString "import Language.Haskell.HLint.Minicute ( hlint )\n"
+  . showString "\n"
+  . showString "main :: IO ()\n"
+  . showString "main = hlint " . shows args
+  ) "\n"

--- a/utilities/hlint/hlint/Main.hs
+++ b/utilities/hlint/hlint/Main.hs
@@ -1,16 +1,2 @@
-module Main
-  ( main
-  ) where
-
-import Language.Haskell.HLint.Minicute ( hlint )
-import System.Exit ( exitFailure, exitSuccess )
-
-main :: IO ()
-main =
-  do
-    -- This 'putStrLn' is to format stack test output
-    putStrLn ""
-    hints <- hlint ["lib"]
-    if null hints
-    then exitSuccess
-    else exitFailure
+{-# OPTIONS_GHC -F -pgmF hlint-run #-}
+{-# OPTIONS_GHC -optF lib #-}

--- a/utilities/hlint/lib/Language/Haskell/HLint/Minicute.hs
+++ b/utilities/hlint/lib/Language/Haskell/HLint/Minicute.hs
@@ -2,22 +2,26 @@ module Language.Haskell.HLint.Minicute
   ( hlint
   ) where
 
-import System.Directory
-import System.FilePath
+import System.Directory ( canonicalizePath, getCurrentDirectory, findFile )
+import System.Exit ( exitFailure, exitSuccess )
+import System.FilePath ( isDrive, (</>) )
 
 import qualified Language.Haskell.HLint3 as HLINT
 
--- |
--- __TODO: Autodetect 'dirs'__
-hlint :: [FilePath] -> IO [HLINT.Idea]
+hlint :: [FilePath] -> IO ()
 hlint dirs = do
+  -- This 'putStrLn' is to format stack test output
+  putStrLn ""
   maybeHlintPath <- findHlintPath
   case maybeHlintPath of
     Just hlintPath ->
       let
         hlintArgs = dirs <> ["--hint=" <> hlintPath]
-      in
-        HLINT.hlint hlintArgs
+      in do
+        hints <- HLINT.hlint hlintArgs
+        if null hints
+        then exitSuccess
+        else exitFailure
     Nothing ->
       fail "The setting file hlint.yaml does not exist in any ancestor directories"
 

--- a/utilities/hlint/package.yaml
+++ b/utilities/hlint/package.yaml
@@ -56,7 +56,22 @@ library:
 
 # internal-libraries:
 
-# executables:
+executables:
+  hlint-run:
+    ### Executable fields ###
+    main:                           Main.hs
+    # other-modules:
+    # generated-other-modules:
+
+    ### Common fields ###
+    source-dirs:
+      - hlint-run
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
+    dependencies:
+      - hlint-minicute-utilities == 0.1.0.0
 
 # executable:
 
@@ -76,6 +91,8 @@ tests:
       - -with-rtsopts=-N
     dependencies:
       - hlint-minicute-utilities
+    build-tools:
+      - hlint-run
 
 # benchmarks:
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
There is too much boilerplate in hlint `Main.hs` files.

**Describe the solution you chose**
Introduce the preprocessor `hlint-run` to generate hlint `Main.hs` files.

**Describe alternatives you've considered**
Use Template Haskell? It probably still needs tons of boilerplate.

**Additional context**
For `-F` preprocessor, see https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/phases.html#pre-processor