### PR TITLE
Fix interpreter

### DIFF
--- a/fixture/infinite.gm
+++ b/fixture/infinite.gm
@@ -1,0 +1,6 @@
+main<0> {
+  MakeGlobal main;
+  Update 1;
+  Pop 1;
+  Unwind;
+}

--- a/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine.hs
@@ -8,6 +8,7 @@ module Minicute.Control.GMachine
 
   , GMachineMonadT
   , GMachineMonad
+  , execGMachineT
 
   , initializeGMachineWith
   , executeGMachineStep
@@ -18,7 +19,7 @@ import Prelude hiding ( fail )
 
 import Control.Monad ( (<=<) )
 import Control.Monad.Fail
-import Control.Monad.State ( MonadState(..), StateT, gets, modify )
+import Control.Monad.State ( MonadState(..), StateT, gets, modify, execStateT )
 import Control.Monad.Trans ( MonadTrans(..) )
 import Control.Monad.Writer ( MonadWriter(..), Writer, runWriter )
 import Data.Data
@@ -61,6 +62,13 @@ instance (Monad m) => MonadState (NonEmpty GMachineState) (GMachineMonadT m) whe
 
 instance MonadTrans GMachineMonadT where
   lift = GMachineMonadT . pure . lift
+
+execGMachineT :: (Monad m) => GMachineMonadT m () -> m (NonEmpty GMachineState)
+execGMachineT (GMachineMonadT a)
+  | Just st <- maySt = execStateT b (st :| [])
+  | otherwise = error "execGMachineT: input G-Machine is not initialized"
+  where
+    (b, First maySt) = runWriter a
 
 
 initializeGMachineWith :: (Monad m) => GMachineProgram -> GMachineMonadT m ()

--- a/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine.hs
@@ -63,7 +63,7 @@ instance (Monad m) => MonadState (NonEmpty GMachineState) (GMachineMonadT m) whe
 instance MonadTrans GMachineMonadT where
   lift = GMachineMonadT . pure . lift
 
-execGMachineT :: (Monad m) => GMachineMonadT m () -> m (NonEmpty GMachineState)
+execGMachineT :: (Monad m) => GMachineMonadT m a -> m (NonEmpty GMachineState)
 execGMachineT (GMachineMonadT a)
   | Just st <- maySt = execStateT b (st :| [])
   | otherwise = error "execGMachineT: input G-Machine is not initialized"

--- a/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine.hs
@@ -31,7 +31,7 @@ import Minicute.Data.GMachine.Instruction
 
 import qualified Data.List.NonEmpty as NonEmpty
 
-type GMachineMonad = GMachineMonadT Maybe
+type GMachineMonad = GMachineMonadT IO
 
 newtype GMachineMonadT m a
   = GMachineMonadT

--- a/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine.hs
@@ -3,50 +3,78 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE StandaloneDeriving #-}
 module Minicute.Control.GMachine
   ( module Minicute.Control.GMachine.Step
 
   , GMachineMonadT
   , GMachineMonad
 
-  , initializeInterpreterWith
-  , addInterpreterStep
-  , checkInterpreterFinished
+  , initializeGMachineWith
+  , executeGMachineStep
+  , checkGMachineFinished
   ) where
 
 import Prelude hiding ( fail )
 
+import Control.Monad ( (<=<) )
 import Control.Monad.Fail
-import Control.Monad.Writer ( MonadWriter(..), WriterT )
+import Control.Monad.State ( MonadState(..), StateT, gets, modify )
+import Control.Monad.Trans ( MonadTrans(..) )
+import Control.Monad.Writer ( MonadWriter(..), Writer, runWriter )
 import Data.Data
+import Data.List.NonEmpty ( NonEmpty(..), (<|) )
+import Data.Monoid ( First(..) )
 import GHC.Generics
 import Minicute.Control.GMachine.Step
 import Minicute.Data.GMachine.Instruction
 
-type GMachineMonad = GMachineMonadT Maybe Maybe
+import qualified Data.List.NonEmpty as NonEmpty
 
--- |
--- _TODO: Add a 'GMachineState' component to build
--- 'checkInterpreterFinished' action
-newtype GMachineMonadT m' m a
+type GMachineMonad = GMachineMonadT Maybe
+
+newtype GMachineMonadT m a
   = GMachineMonadT
-    (WriterT [GMachineStepMonadT m' ()] m a)
+    { runGMachineMonadT :: Writer (First GMachineState) (StateT (NonEmpty GMachineState) m a)
+    }
   deriving ( Generic
            , Typeable
            , Functor
-           , Applicative
-           , Monad
-           , MonadFail
            )
 
-deriving instance (Monad m) => MonadWriter [GMachineStepMonadT m' ()] (GMachineMonadT m' m)
+instance (Monad m) => Applicative (GMachineMonadT m) where
+  pure = GMachineMonadT . pure . pure
+  (GMachineMonadT f) <*> (GMachineMonadT a)
+    = GMachineMonadT $ fmap (<*>) f <*> a
 
-initializeInterpreterWith :: (Monad m) => GMachineProgram -> GMachineMonadT m' m ()
-initializeInterpreterWith = pure . const ()
+instance (Monad m) => Monad (GMachineMonadT m) where
+  (GMachineMonadT a) >>= f
+    = GMachineMonadT
+      $ (>>= fst . runWriter . runGMachineMonadT . f) <$> a
 
-addInterpreterStep :: (Monad m) => GMachineStepMonadT m' () -> GMachineMonadT m' m ()
-addInterpreterStep = tell . pure
+instance (MonadFail m) => MonadFail (GMachineMonadT m) where
+  fail = GMachineMonadT . pure . fail
 
-checkInterpreterFinished :: (Monad m) => GMachineMonadT m' m Bool
-checkInterpreterFinished = undefined
+instance (Monad m) => MonadState (NonEmpty GMachineState) (GMachineMonadT m) where
+  get = GMachineMonadT . pure $ get
+  put = GMachineMonadT . pure . put
+  state = GMachineMonadT . pure . state
+
+instance MonadTrans GMachineMonadT where
+  lift = GMachineMonadT . pure . lift
+
+
+initializeGMachineWith :: (Monad m) => GMachineProgram -> GMachineMonadT m ()
+initializeGMachineWith
+  = GMachineMonadT
+    . ( pure . pure
+        <=< tell . First . Just . buildInitialState
+      )
+
+executeGMachineStep :: (Monad m) => GMachineStepMonadT m () -> GMachineMonadT m ()
+executeGMachineStep step = do
+  st <- gets NonEmpty.head
+  st' <- lift . execGMachineStepT step $ st
+  modify (st' <|)
+
+checkGMachineFinished :: (Monad m) => GMachineMonadT m Bool
+checkGMachineFinished = gets (checkTerminalState . NonEmpty.head)

--- a/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine/Step.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine/Step.hs
@@ -15,7 +15,8 @@ module Minicute.Control.GMachine.Step
 import Prelude hiding ( fail )
 
 import Control.Monad.Fail
-import Control.Monad.State ( MonadState, StateT, runStateT )
+import Control.Monad.State ( MonadState(..), StateT, runStateT )
+import Control.Monad.Trans ( MonadTrans(..) )
 import Data.Data
 import GHC.Generics
 import Minicute.Data.GMachine.State
@@ -29,6 +30,7 @@ newtype GMachineStepMonadT m a = GMachineStepMonadT (StateT GMachineState m a)
            , Applicative
            , Monad
            , MonadFail
+           , MonadTrans
            )
 
 deriving instance (Monad m) => MonadState GMachineState (GMachineStepMonadT m)

--- a/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine/Step.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Control/GMachine/Step.hs
@@ -21,7 +21,7 @@ import Data.Data
 import GHC.Generics
 import Minicute.Data.GMachine.State
 
-type GMachineStepMonad = GMachineStepMonadT Maybe
+type GMachineStepMonad = GMachineStepMonadT IO
 
 newtype GMachineStepMonadT m a = GMachineStepMonadT (StateT GMachineState m a)
   deriving ( Generic

--- a/main-packages/g-machine-interpreter/lib/Minicute/Data/GMachine/AddressStack.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Data/GMachine/AddressStack.hs
@@ -89,6 +89,6 @@ peekNthAddr n = use _Wrapped >>= peekNthAddr'
         _ -> fail $ "peekNthAddr: There are not enough addresses to peek the " <> show n <> "th address"
 
 checkSize :: (MonadState s m, s ~ AddressStack) => Int -> m Bool
-checkSize n = isLongerThan n <$> use _Wrapped
+checkSize n = isLongEnough <$> use _Wrapped
   where
-    isLongerThan len = not . null . drop (len - 1)
+    isLongEnough = (n ==) . length . take n

--- a/main-packages/g-machine-interpreter/lib/Minicute/Data/GMachine/State.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Data/GMachine/State.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/main-packages/g-machine-interpreter/lib/Minicute/Data/GMachine/State.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Data/GMachine/State.hs
@@ -10,6 +10,7 @@
 module Minicute.Data.GMachine.State
   ( GMachineState
   , buildInitialState
+  , checkTerminalState
 
   , fetchNextInstruction
   , putInstruction
@@ -53,6 +54,7 @@ import Control.Monad.Fail
 import Control.Monad.State
   ( MonadState
   , StateT
+  , evalState
   , execState
   , runState
   , runStateT
@@ -125,6 +127,12 @@ buildInitialState program
     buildGlobal
       = forM globalEntries
         $ uncurry Global.allocAddress
+
+checkTerminalState :: GMachineState -> Bool
+checkTerminalState state
+  = state ^. _code == Code.empty
+  && evalState (AddressStack.checkSize 1) (state ^. _addressStack)
+  && state ^. _valueStack == ValueStack.empty
 
 
 fetchNextInstruction :: (MonadState s m, s ~ GMachineState, MonadFail m) => m Code.Instruction

--- a/main-packages/g-machine-interpreter/lib/Minicute/Interpreter/GMachine.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Interpreter/GMachine.hs
@@ -11,10 +11,10 @@ import Minicute.Interpreter.GMachine.Instruction
 
 interpretProgram :: GMachineProgram -> GMachineMonad ()
 interpretProgram program
-  = initializeInterpreterWith program >> buildSteps
+  = initializeGMachineWith program >> buildSteps
   where
     buildSteps
-      = ifM checkInterpreterFinished
-        (addInterpreterStep step >> buildSteps)
+      = ifM checkGMachineFinished
+        (executeGMachineStep step >> buildSteps)
         (pure ())
     step = fetchNextInstruction >>= interpretInstruction

--- a/main-packages/g-machine-interpreter/lib/Minicute/Interpreter/GMachine.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Interpreter/GMachine.hs
@@ -15,6 +15,6 @@ interpretProgram program
   where
     buildSteps
       = ifM checkGMachineFinished
-        (executeGMachineStep step >> buildSteps)
         (pure ())
+        (executeGMachineStep step >> buildSteps)
     step = fetchNextInstruction >>= interpretInstruction

--- a/main-packages/g-machine-interpreter/lib/Minicute/Interpreter/GMachine/Instruction.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Interpreter/GMachine/Instruction.hs
@@ -88,12 +88,12 @@ interpretDig n = do
 interpretUpdate :: Int -> GMachineStepMonad ()
 interpretUpdate n = do
   valueAddr <- peekAddrOnAddressStack
-  targetAddr <- peekNthAddrOnAddressStack n
+  targetAddr <- peekNthAddrOnAddressStack (n + 1)
   updateNodeOnNodeHeap targetAddr (NIndirect valueAddr)
 
 interpretCopy :: Int -> GMachineStepMonad ()
 interpretCopy n = do
-  addr <- peekNthAddrOnAddressStack n
+  addr <- peekNthAddrOnAddressStack (n + 1)
   pushAddrToAddressStack addr
 
 
@@ -135,13 +135,13 @@ interpretWrapAsStructure = do
 
 interpretUpdateAsInteger :: Int -> GMachineStepMonad ()
 interpretUpdateAsInteger n = do
-  targetAddr <- peekNthAddrOnAddressStack n
+  targetAddr <- peekNthAddrOnAddressStack (n + 1)
   v <- popValueFromValueStack
   updateNodeOnNodeHeap targetAddr (NInteger v)
 
 interpretUpdateAsStructure :: Int -> GMachineStepMonad ()
 interpretUpdateAsStructure n = do
-  targetAddr <- peekNthAddrOnAddressStack n
+  targetAddr <- peekNthAddrOnAddressStack (n + 1)
   v <- popValueFromValueStack
   fieldsAddr <- allocNodeOnNodeHeap (NStructureFields 0 [])
   updateNodeOnNodeHeap targetAddr (NStructure v fieldsAddr)

--- a/main-packages/g-machine-interpreter/lib/Minicute/Interpreter/GMachine/Instruction.hs
+++ b/main-packages/g-machine-interpreter/lib/Minicute/Interpreter/GMachine/Instruction.hs
@@ -177,9 +177,12 @@ interpretUnwind = do
     NIndirect addr' -> do
       putInstruction IUnwind
       pushAddrToAddressStack addr'
+    NGlobal 0 code -> do
+      pushAddrToAddressStack addr
+      putInstructions code
     NGlobal n code ->
       ifM (checkSizeOfAddressStack (fromInteger n))
-        (putInstructions code >> rearrangeStack (fromInteger (n - 1)))
+        (putInstructions code >> rearrangeStack (fromInteger n))
         (putInstruction IReturn)
     (isValueNode -> True) -> do
       loadStateFromDump
@@ -191,11 +194,13 @@ interpretUnwind = do
         <> " case is not allowed"
       )
   where
+    -- @n@ should be greater than @1@.
+    --
     -- Please check the direction of addrs.
     -- __WARNING: the direction actually affects correctness.__
     rearrangeStack :: Int -> GMachineStepMonad ()
     rearrangeStack n = do
-      addrs <- popAddrsFromAddressStack (n + 1)
+      addrs <- popAddrsFromAddressStack n
       pushAddrToAddressStack (last addrs)
       applyeeAddrs <- forM addrs $ \addr -> do
         node <- findNodeOnNodeHeap addr
@@ -203,7 +208,7 @@ interpretUnwind = do
           NApplication _ applyeeAddr ->
             pure applyeeAddr
           _ ->
-            fail "rearrangeStack: Invalid invocation of the function. Top most n nodes have to be NApplication nodes"
+            fail $ "rearrangeStack: Invalid invocation of the function. Top most " <> show n <> " nodes have to be NApplication nodes"
       pushAddrsToAddressStack applyeeAddrs
 
 interpretEval :: GMachineStepMonad ()

--- a/main-packages/g-machine-interpreter/minicute-g/Main.hs
+++ b/main-packages/g-machine-interpreter/minicute-g/Main.hs
@@ -27,7 +27,7 @@ interpret handle = do
       print program
       states <- execGMachineT (interpretProgram program)
       putStrLn "Execution states:"
-      let indexedStates = zip (toList states) [(0 :: Integer)..]
+      let indexedStates = zip (reverse (toList states)) [(0 :: Integer)..]
       forM_ indexedStates $ \(state, index) -> do
         putStrLn $ "  state<" <> show index <> ">:"
         putStrLn $ "    " <> show  state

--- a/main-packages/g-machine-interpreter/minicute-g/Main.hs
+++ b/main-packages/g-machine-interpreter/minicute-g/Main.hs
@@ -2,6 +2,9 @@ module Main
   ( main
   ) where
 
+import Control.Monad ( forM_ )
+import Data.List.NonEmpty ( toList )
+import Minicute.Interpreter.GMachine ( execGMachineT, interpretProgram )
 import Minicute.Parser.GMachine.Parser ( gMachineProgram )
 import System.Environment
 import System.IO
@@ -22,6 +25,12 @@ interpret handle = do
     Right program -> do
       putStrLn "program by show:"
       print program
+      states <- execGMachineT (interpretProgram program)
+      putStrLn "Execution states:"
+      let indexedStates = zip (toList states) [(0 :: Integer)..]
+      forM_ indexedStates $ \(state, index) -> do
+        putStrLn $ "  state<" <> show index <> ">:"
+        putStrLn $ "    " <> show  state
     Left err -> do
       putStrLn "error:"
       putStrLn (errorBundlePretty err)

--- a/main-packages/g-machine-syntax/lib/Minicute/Data/GMachine/Instruction.hs
+++ b/main-packages/g-machine-syntax/lib/Minicute/Data/GMachine/Instruction.hs
@@ -129,7 +129,7 @@ type GMachineExpression = [Instruction]
 --       ( & IMakePlaceholders\ n : codes, &                                  addrs, & values, & dump, & heap, &  global & )\\
 --       \hline
 --       ( &                        codes, & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap', & global & )
---     \end{array}\\[1em]
+--     \end{array}\\
 --     & heap' = heap[addr_0: NEmpty, addr_1: NEmpty, ..., addr_n: NEmpty]
 --     \end{align}
 --     \]
@@ -310,10 +310,21 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( &                                [IUnwind], &    addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap[addr_0: NConstructor\ t\ n], & global & )\\
+--       ( &          [IUnwind], & addr : addrs, & values, & dump, & heap[addr: NConstructor\ t\ 0], & global & )\\
 --       \hline
---       ( & IRearrange\ (n - 1) : constructorCode\ t, &             addr_1 : ... : addr_n : addrs, & values, & dump, & heap, &                             global & )
+--       ( & constructorCode\ t, & addr : addrs, & values, & dump, & heap, &                           global & )
 --     \end{array}
+--     \]
+--
+--     \[
+--     \begin{align}
+--     & \begin{array}{r r r r r l l l}
+--       ( &                          [IUnwind], & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap[addr_0: NConstructor\ t\ n], & global & )\\
+--       \hline
+--       ( & IRearrange\ n : constructorCode\ t, &          addr_1 : ... : addr_n : addrs, & values, & dump, & heap, &                             global & )
+--     \end{array}\\
+--     & \text{(when $n > 0$)}
+--     \end{align}
 --     \]
 --
 --     \[
@@ -329,10 +340,21 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( &                    [IUnwind], &    addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap[addr_0: NGlobal\ n\ codes'], & global & )\\
+--       ( & [IUnwind], & addr : addrs, & values, & dump, & heap[addr: NGlobal\ 0\ codes'], & global & )\\
 --       \hline
---       ( & IRearrange\ (n - 1) : codes', &             addr_1 : ... : addr_n : addrs, & values, & dump, & heap, &                             global & )
+--       ( &    codes', & addr : addrs, & values, & dump, & heap, &                           global & )
 --     \end{array}
+--     \]
+--
+--     \[
+--     \begin{align}
+--     & \begin{array}{r r r r r l l l}
+--       ( &              [IUnwind], & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap[addr_0: NGlobal\ n\ codes'], & global & )\\
+--       \hline
+--       ( & IRearrange\ n : codes', &          addr_1 : ... : addr_n : addrs, & values, & dump, & heap, &                             global & )
+--     \end{array}\\
+--     & \text{(when $n > 0$)}
+--     \end{align}
 --     \]
 --
 --     \[
@@ -386,7 +408,7 @@ type GMachineExpression = [Instruction]
 --     \begin{array}{r r r r r l l l}
 --       ( & IMatch\ table[t: caseCode] : codes, & addr : addrs, & values, & dump, & heap[addr: NStructure\ t\ fAddrs], & global & )\\
 --       \hline
---       ( &                 caseCode <> codes, & addr : addrs, & values, & dump, & heap, &                              global & )
+--       ( &            caseCode \diamond codes, & addr : addrs, & values, & dump, & heap, &                              global & )
 --     \end{array}
 --     \]
 --
@@ -398,9 +420,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IRearrange\ n : codes, &             addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap[addr_i: NApplication\ addr_i''\ addr_i'], & global & )\\
+--       ( & IRearrange\ n : codes, &                    addr_0 : addr_1 : ... : addr_{n - 1} : addrs, & values, & dump, & heap[addr_i: NApplication\ addr'_i\ addr''_i], & global & )\\
 --       \hline
---       ( &                 codes, & addr_0' : addr_1' : ... : addr_n' : addr_n : addrs, & values, & dump, & heap, &                                         global & )
+--       ( &                 codes, & addr''_0 : addr''_1 : ... : addr''_{n - 1} : addr_{n - 1} : addrs, & values, & dump, & heap, &                                         global & )
 --     \end{array}\\
 --     \]
 

--- a/main-packages/g-machine-syntax/lib/Minicute/Data/GMachine/Instruction.hs
+++ b/main-packages/g-machine-syntax/lib/Minicute/Data/GMachine/Instruction.hs
@@ -74,9 +74,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IMakeInteger\ n : codes, &        addrs, & values, & dump, & heap, &                    global & )\\
+--       ( & \text{IMakeInteger}\ n : codes, &        addrs, & values, & dump, & heap, &                           global & )\\
 --       \hline
---       ( &                   codes, & addr : addrs, & values, & dump, & heap[addr: NInteger\ n], & global & )
+--       ( &                          codes, & addr : addrs, & values, & dump, & heap[addr: \text{NInteger}\ n], & global & )
 --     \end{array}
 --     \]
 --
@@ -85,9 +85,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IMakeConstructor\ t\ n : codes, &        addrs, & values, & dump, & heap, &                           global & )\\
+--       ( & \text{IMakeConstructor}\ t\ n : codes, &        addrs, & values, & dump, & heap, &                                  global & )\\
 --       \hline
---       ( &                          codes, & addr : addrs, & values, & dump, & heap[addr: NConstructor\ t\ n], & global & )
+--       ( &                                 codes, & addr : addrs, & values, & dump, & heap[addr: \text{NConstructor}\ t\ n], & global & )
 --     \end{array}
 --     \]
 --
@@ -95,9 +95,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IMakeStructure\ t\ n : codes, & addr_0 : addr_1 : ... : addr_{n - 1} : addrs, & values, & dump, & heap, &                                                           global & )\\
+--       ( & \text{IMakeStructure}\ t\ n : codes, & addr_0 : addr_1 : ... : addr_{n - 1} : addrs, & values, & dump, & heap, &                                                                  global & )\\
 --       \hline
---       ( &                        codes, &                                 addr : addrs, & values, & dump, & heap[addr: NStructure\ t\ [addr_{n - 1}, ..., addr_1, addr_0]], & global & )
+--       ( &                               codes, &                                 addr : addrs, & values, & dump, & heap[addr: \text{NStructure}\ t\ [addr_{n - 1}, ..., addr_1, addr_0]], & global & )
 --     \end{array}
 --     \]
 --
@@ -105,9 +105,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IMakeApplication : codes, & addr_0 : addr_1 : addrs, & values, & dump, & heap, &                                     global & )\\
+--       ( & \text{IMakeApplication} : codes, & addr_0 : addr_1 : addrs, & values, & dump, & heap, &                                            global & )\\
 --       \hline
---       ( &                    codes, &            addr : addrs, & values, & dump, & heap[addr: NApplication\ addr_1\ addr_0], & global & )
+--       ( &                           codes, &            addr : addrs, & values, & dump, & heap[addr: \text{NApplication}\ addr_1\ addr_0], & global & )
 --     \end{array}
 --     \]
 --
@@ -115,9 +115,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IMakeGlobal\ id : codes, &        addrs, & values, & dump, & heap, & global[id: addr] & )\\
+--       ( & \text{IMakeGlobal}\ id : codes, &        addrs, & values, & dump, & heap, & global[id: addr] & )\\
 --       \hline
---       ( &                   codes, & addr : addrs, & values, & dump, & heap, & global[id: addr] & )
+--       ( &                          codes, & addr : addrs, & values, & dump, & heap, & global[id: addr] & )
 --     \end{array}
 --     \]
 --
@@ -126,11 +126,11 @@ type GMachineExpression = [Instruction]
 --     \[
 --     \begin{align}
 --     & \begin{array}{r r r r r l l l}
---       ( & IMakePlaceholders\ n : codes, &                                  addrs, & values, & dump, & heap, &  global & )\\
+--       ( & \text{IMakePlaceholders}\ n : codes, &                                  addrs, & values, & dump, & heap, &  global & )\\
 --       \hline
---       ( &                        codes, & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap', & global & )
+--       ( &                               codes, & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap', & global & )
 --     \end{array}\\
---     & heap' = heap[addr_0: NEmpty, addr_1: NEmpty, ..., addr_n: NEmpty]
+--     & heap' = heap[addr_0: \text{NEmpty}, addr_1: \text{NEmpty}, ..., addr_n: \text{NEmpty}]
 --     \end{align}
 --     \]
 --
@@ -141,9 +141,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IPop\ n : codes, & addr_0 : addr_1 : ... : addr_{n - 1} : addrs, & values, & dump, & heap, & global & )\\
+--       ( & \text{IPop}\ n : codes, & addr_0 : addr_1 : ... : addr_{n - 1} : addrs, & values, & dump, & heap, & global & )\\
 --       \hline
---       ( &           codes, &                                        addrs, & values, & dump, & heap, & global & )
+--       ( &                  codes, &                                        addrs, & values, & dump, & heap, & global & )
 --     \end{array}
 --     \]
 --
@@ -151,9 +151,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IDig\ n : codes, & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap, & global & )\\
+--       ( & \text{IDig}\ n : codes, & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap, & global & )\\
 --       \hline
---       ( &           codes, &                         addr_0 : addrs, & values, & dump, & heap, & global & )
+--       ( &                  codes, &                         addr_0 : addrs, & values, & dump, & heap, & global & )
 --     \end{array}
 --     \]
 --
@@ -161,9 +161,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IUpdate\ n : codes, & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap, &                            global & )\\
+--       ( & \text{IUpdate}\ n : codes, & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap, &                                   global & )\\
 --       \hline
---       ( &              codes, & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap[addr_n: NIndirect\ addr_0], & global & )
+--       ( &                     codes, & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap[addr_n: \text{NIndirect}\ addr_0], & global & )
 --     \end{array}
 --     \]
 --
@@ -171,9 +171,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & ICopy\ n : codes, &          addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap, & global & )\\
+--       ( & \text{ICopy}\ n : codes, &          addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap, & global & )\\
 --       \hline
---       ( &            codes, & addr_n : addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap, & global & )
+--       ( &                   codes, & addr_n : addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap, & global & )
 --     \end{array}
 --     \]
 --
@@ -182,9 +182,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IPushBasicValue\ v : codes, & addrs, &     values, & dump, & heap, & global & )\\
+--       ( & \text{IPushBasicValue}\ v : codes, & addrs, &     values, & dump, & heap, & global & )\\
 --       \hline
---       ( &                      codes, & addrs, & v : values, & dump, & heap, & global & )
+--       ( &                             codes, & addrs, & v : values, & dump, & heap, & global & )
 --     \end{array}
 --     \]
 --
@@ -192,17 +192,17 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IPushExtractedValue : codes, & addr : addrs, &     values, & dump, & heap[addr: NInteger\ v], & global & )\\
+--       ( & \text{IPushExtractedValue} : codes, & addr : addrs, &     values, & dump, & heap[addr: \text{NInteger}\ v], & global & )\\
 --       \hline
---       ( &                       codes, &        addrs, & v : values, & dump, & heap, &                    global & )
+--       ( &                              codes, &        addrs, & v : values, & dump, & heap, &                           global & )
 --     \end{array}
 --     \]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IPushExtractedValue : codes, & addr : addrs, &     values, & dump, & heap[addr: NStructure\ v\ []], & global & )\\
+--       ( & \text{IPushExtractedValue} : codes, & addr : addrs, &     values, & dump, & heap[addr: \text{NStructure}\ v\ []], & global & )\\
 --       \hline
---       ( &                       codes, &        addrs, & v : values, & dump, & heap, &                          global & )
+--       ( &                              codes, &        addrs, & v : values, & dump, & heap, &                                 global & )
 --     \end{array}
 --     \]
 --
@@ -210,9 +210,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IWrapAsInteger : codes, &        addrs, & v : values, & dump, & heap, &                    global & )\\
+--       ( & \text{IWrapAsInteger} : codes, &        addrs, & v : values, & dump, & heap, &                           global & )\\
 --       \hline
---       ( &                  codes, & addr : addrs, &     values, & dump, & heap[addr: NInteger\ v], & global & )
+--       ( &                         codes, & addr : addrs, &     values, & dump, & heap[addr: \text{NInteger}\ v], & global & )
 --     \end{array}
 --     \]
 --
@@ -220,9 +220,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IWrapAsStructure : codes, &        addrs, & v : values, & dump, & heap, &                          global & )\\
+--       ( & \text{IWrapAsStructure} : codes, &        addrs, & v : values, & dump, & heap, &                                 global & )\\
 --       \hline
---       ( &                    codes, & addr : addrs, &     values, & dump, & heap[addr: NStructure\ v\ []], & global & )
+--       ( &                           codes, & addr : addrs, &     values, & dump, & heap[addr: \text{NStructure}\ v\ []], & global & )
 --     \end{array}
 --     \]
 --
@@ -230,9 +230,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IUpdateAsInteger\ n : codes, & addr_0 : addr_1 : ... : addr_n : addrs, & v : values, & dump, & heap, &                      global & )\\
+--       ( & \text{IUpdateAsInteger}\ n : codes, & addr_0 : addr_1 : ... : addr_n : addrs, & v : values, & dump, & heap, &                             global & )\\
 --       \hline
---       ( &                       codes, & addr_0 : addr_1 : ... : addr_n : addrs, &     values, & dump, & heap[addr_n: NInteger\ v], & global & )
+--       ( &                              codes, & addr_0 : addr_1 : ... : addr_n : addrs, &     values, & dump, & heap[addr_n: \text{NInteger}\ v], & global & )
 --     \end{array}
 --     \]
 --
@@ -240,9 +240,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IUpdateAsStructure\ n : codes, & addr_0 : addr_1 : ... : addr_n : addrs, & v : values, & dump, & heap, &                            global & )\\
+--       ( & \text{IUpdateAsStructure}\ n : codes, & addr_0 : addr_1 : ... : addr_n : addrs, & v : values, & dump, & heap, &                                   global & )\\
 --       \hline
---       ( &                         codes, & addr_0 : addr_1 : ... : addr_n : addrs, &     values, & dump, & heap[addr_n: NStructure\ v\ []], & global & )
+--       ( &                                codes, & addr_0 : addr_1 : ... : addr_n : addrs, &     values, & dump, & heap[addr_n: \text{NStructure}\ v\ []], & global & )
 --     \end{array}
 --     \]
 --
@@ -252,9 +252,9 @@ type GMachineExpression = [Instruction]
 --     \[
 --     \begin{align}
 --     & \begin{array}{r r r r r l l l}
---       ( & IPrimitive\ op : codes, & addrs, & v_0 : v_1 : values, & dump, & heap, & global & )\\
+--       ( & \text{IPrimitive}\ op : codes, & addrs, & v_0 : v_1 : values, & dump, & heap, & global & )\\
 --       \hline
---       ( &                  codes, & addrs, &        v' : values, & dump, & heap, & global & )
+--       ( &                         codes, & addrs, &        v' : values, & dump, & heap, & global & )
 --     \end{array}\\
 --     & v' = v_0\ R\ v1\\
 --     & \text{(when $op$ represents a binary operation $R$)}
@@ -264,9 +264,9 @@ type GMachineExpression = [Instruction]
 --     \[
 --     \begin{align}
 --     & \begin{array}{r r r r r l l l}
---       ( & IPrimitive\ op : codes, & addrs, &  v : values, & dump, & heap, & global & )\\
+--       ( & \text{IPrimitive}\ op : codes, & addrs, &  v : values, & dump, & heap, & global & )\\
 --       \hline
---       ( &                  codes, & addrs, & v' : values, & dump, & heap, & global & )
+--       ( &                         codes, & addrs, & v' : values, & dump, & heap, & global & )
 --     \end{array}\\
 --     & v' = R\ v\\
 --     & \text{(when $op$ represents a unary operation $R$)}
@@ -278,50 +278,50 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & [IUnwind], &  addr : addrs, &  values, & (codes', addrs', values') : dump, & heap[addr: NInteger\ n], & global & )\\
+--       ( & [\text{IUnwind}], &  addr : addrs, &  values, & (codes', addrs', values') : dump, & heap[addr: \text{NInteger}\ n], & global & )\\
 --       \hline
---       ( &    codes', & addr : addrs', & values', &                             dump, & heap, &                    global & )
+--       ( &           codes', & addr : addrs', & values', &                             dump, & heap, &                           global & )
 --     \end{array}
 --     \]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & [IUnwind], &  addr : addrs, &  values, & (codes', addrs', values') : dump, & heap[addr: NStructure\ t\ fAddrs], & global & )\\
+--       ( & [\text{IUnwind}], &  addr : addrs, &  values, & (codes', addrs', values') : dump, & heap[addr: \text{NStructure}\ t\ fAddrs], & global & )\\
 --       \hline
---       ( &    codes', & addr : addrs', & values', &                             dump, & heap, &                              global & )
+--       ( &           codes', & addr : addrs', & values', &                             dump, & heap, &                                     global & )
 --     \end{array}
 --     \]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & [IUnwind], &          addr : addrs, & values, & dump, & heap[addr: NApplication\ addr_1\ addr_0], & global & )\\
+--       ( & [\text{IUnwind}], &          addr : addrs, & values, & dump, & heap[addr: \text{NApplication}\ addr_1\ addr_0], & global & )\\
 --       \hline
---       ( & [IUnwind], & addr_1 : addr : addrs, & values, & dump, & heap, &                                     global & )
+--       ( & [\text{IUnwind}], & addr_1 : addr : addrs, & values, & dump, & heap, &                                            global & )
 --     \end{array}
 --     \]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & [IUnwind], &  addr : addrs, & values, & dump, & heap[addr: NIndirect\ addr'], & global & )\\
+--       ( & [\text{IUnwind}], &  addr : addrs, & values, & dump, & heap[addr: \text{NIndirect}\ addr'], & global & )\\
 --       \hline
---       ( & [IUnwind], & addr' : addrs, & values, & dump, & heap, &                         global & )
+--       ( & [\text{IUnwind}], & addr' : addrs, & values, & dump, & heap, &                                global & )
 --     \end{array}
 --     \]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( &          [IUnwind], & addr : addrs, & values, & dump, & heap[addr: NConstructor\ t\ 0], & global & )\\
+--       ( &          [\text{IUnwind}], & addr : addrs, & values, & dump, & heap[addr: \text{NConstructor}\ t\ 0], & global & )\\
 --       \hline
---       ( & constructorCode\ t, & addr : addrs, & values, & dump, & heap, &                           global & )
+--       ( & \text{constructorCode}\ t, & addr : addrs, & values, & dump, & heap, &                                  global & )
 --     \end{array}
 --     \]
 --
 --     \[
 --     \begin{align}
 --     & \begin{array}{r r r r r l l l}
---       ( &                          [IUnwind], & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap[addr_0: NConstructor\ t\ n], & global & )\\
+--       ( &                                 [\text{IUnwind}], & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap[addr_0: \text{NConstructor}\ t\ n], & global & )\\
 --       \hline
---       ( & IRearrange\ n : constructorCode\ t, &          addr_1 : ... : addr_n : addrs, & values, & dump, & heap, &                             global & )
+--       ( & \text{IRearrange}\ n : \text{constructorCode}\ t, &          addr_1 : ... : addr_n : addrs, & values, & dump, & heap, &                                    global & )
 --     \end{array}\\
 --     & \text{(when $n > 0$)}
 --     \end{align}
@@ -330,9 +330,9 @@ type GMachineExpression = [Instruction]
 --     \[
 --     \begin{align}
 --     & \begin{array}{r r r r r l l l}
---       ( & [IUnwind], & [addr_0, addr_1, ..., addr_m], & values, & dump, & heap[addr_0: NConstructor\ t\ n], & global & )\\
+--       ( & [\text{IUnwind}], & [addr_0, addr_1, ..., addr_m], & values, & dump, & heap[addr_0: \text{NConstructor}\ t\ n], & global & )\\
 --       \hline
---       ( &  [Return], & [addr_0, addr_1, ..., addr_m], & values, & dump, & heap, &                             global & )
+--       ( &  [\text{Return}], & [addr_0, addr_1, ..., addr_m], & values, & dump, & heap, &                                    global & )
 --     \end{array}\\
 --     & \text{(when $m < n$)}
 --     \end{align}
@@ -340,18 +340,18 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & [IUnwind], & addr : addrs, & values, & dump, & heap[addr: NGlobal\ 0\ codes'], & global & )\\
+--       ( & [\text{IUnwind}], & addr : addrs, & values, & dump, & heap[addr: \text{NGlobal}\ 0\ codes'], & global & )\\
 --       \hline
---       ( &    codes', & addr : addrs, & values, & dump, & heap, &                           global & )
+--       ( &           codes', & addr : addrs, & values, & dump, & heap, &                                  global & )
 --     \end{array}
 --     \]
 --
 --     \[
 --     \begin{align}
 --     & \begin{array}{r r r r r l l l}
---       ( &              [IUnwind], & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap[addr_0: NGlobal\ n\ codes'], & global & )\\
+--       ( &              [\text{IUnwind}], & addr_0 : addr_1 : ... : addr_n : addrs, & values, & dump, & heap[addr_0: \text{NGlobal}\ n\ codes'], & global & )\\
 --       \hline
---       ( & IRearrange\ n : codes', &          addr_1 : ... : addr_n : addrs, & values, & dump, & heap, &                             global & )
+--       ( & \text{IRearrange}\ n : codes', &          addr_1 : ... : addr_n : addrs, & values, & dump, & heap, &                                    global & )
 --     \end{array}\\
 --     & \text{(when $n > 0$)}
 --     \end{align}
@@ -360,9 +360,9 @@ type GMachineExpression = [Instruction]
 --     \[
 --     \begin{align}
 --     & \begin{array}{r r r r r l l l}
---       ( & [IUnwind], & [addr_0, addr_1, ..., addr_m], & values, & dump, & heap[addr_0: NGlobal\ t\ codes'], & global & )\\
+--       ( & [\text{IUnwind}], & [addr_0, addr_1, ..., addr_m], & values, & dump, & heap[addr_0: \text{NGlobal}\ t\ codes'], & global & )\\
 --       \hline
---       ( &  [Return], & [addr_0, addr_1, ..., addr_m], & values, & dump, & heap, &                             global & )
+--       ( &  [\text{Return}], & [addr_0, addr_1, ..., addr_m], & values, & dump, & heap, &                                    global & )
 --     \end{array}\\
 --     & \text{(when $m < n$)}
 --     \end{align}
@@ -372,9 +372,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IDestruct\ n : codes, &                                 addr : addrs, & values, & dump, & heap[addr: NStructure\ t\ [addr_{n - 1}, ..., addr_1, addr_0]], & global & )\\
+--       ( & \text{IDestruct}\ n : codes, &                                 addr : addrs, & values, & dump, & heap[addr: \text{NStructure}\ t\ [addr_{n - 1}, ..., addr_1, addr_0]], & global & )\\
 --       \hline
---       ( &                codes, & addr_0 : addr_1 : ... : addr_{n - 1} : addrs, & values, & dump, & heap, &                                                           global & )
+--       ( &                       codes, & addr_0 : addr_1 : ... : addr_{n - 1} : addrs, & values, & dump, & heap, &                                                                  global & )
 --     \end{array}
 --     \]
 --
@@ -384,9 +384,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IEval : codes, & addr : addrs, & values, &                          dump, & heap, & global & )\\
+--       ( & \text{IEval} : codes, & addr : addrs, & values, &                          dump, & heap, & global & )\\
 --       \hline
---       ( &     [IUnwind], &       [addr], &     [], & (codes, addrs, values) : dump, & heap, & global & )
+--       ( &     [\text{IUnwind}], &       [addr], &     [], & (codes, addrs, values) : dump, & heap, & global & )
 --     \end{array}
 --     \]
 --
@@ -394,9 +394,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & [IReturn], & [addr_0, addr_1, ..., addr_n], &  values, & (codes', addrs', values') : dump, & heap, & global & )\\
+--       ( & [\text{IReturn}], & [addr_0, addr_1, ..., addr_n], &  values, & (codes', addrs', values') : dump, & heap, & global & )\\
 --       \hline
---       ( &    codes', &               addr_n : addrs', & values', &                             dump, & heap, & global & )
+--       ( &           codes', &               addr_n : addrs', & values', &                             dump, & heap, & global & )
 --     \end{array}
 --     \]
 --
@@ -406,9 +406,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IMatch\ table[t: caseCode] : codes, & addr : addrs, & values, & dump, & heap[addr: NStructure\ t\ fAddrs], & global & )\\
+--       ( & \text{IMatch}\ table[t: casecode_t] : codes, & addr : addrs, & values, & dump, & heap[addr: \text{NStructure}\ t\ fAddrs], & global & )\\
 --       \hline
---       ( &            caseCode \diamond codes, & addr : addrs, & values, & dump, & heap, &                              global & )
+--       ( &                   casecode_t \diamond codes, & addr : addrs, & values, & dump, & heap, &                                     global & )
 --     \end{array}
 --     \]
 --
@@ -420,9 +420,9 @@ type GMachineExpression = [Instruction]
 --
 --     \[
 --     \begin{array}{r r r r r l l l}
---       ( & IRearrange\ n : codes, &                    addr_0 : addr_1 : ... : addr_{n - 1} : addrs, & values, & dump, & heap[addr_i: NApplication\ addr'_i\ addr''_i], & global & )\\
+--       ( & \text{IRearrange}\ n : codes, &                    addr_0 : addr_1 : ... : addr_{n - 1} : addrs, & values, & dump, & heap[addr_i: \text{NApplication}\ addr'_i\ addr''_i], & global & )\\
 --       \hline
---       ( &                 codes, & addr''_0 : addr''_1 : ... : addr''_{n - 1} : addr_{n - 1} : addrs, & values, & dump, & heap, &                                         global & )
+--       ( &                        codes, & addr''_0 : addr''_1 : ... : addr''_{n - 1} : addr_{n - 1} : addrs, & values, & dump, & heap, &                                               global & )
 --     \end{array}\\
 --     \]
 

--- a/main-packages/g-machine-syntax/lib/Minicute/Data/GMachine/Instruction.hs
+++ b/main-packages/g-machine-syntax/lib/Minicute/Data/GMachine/Instruction.hs
@@ -64,6 +64,18 @@ type GMachineExpression = [Instruction]
 --
 -- [@GlobalEnvironment@] a map from identifiers to addresses of corresponding nodes.
 --
+-- The following tuple describes the initial state for the machine.
+--
+--     \[
+--     \begin{align}
+--     & \begin{array}{r r r r r l l l}
+--       ( & [\text{IMakeGlobal}\ \unicode{x201C}main\unicode{x201D}, \text{IEval}], & [], & [], & [], & initialHeap, & initialGlobal & )
+--     \end{array}\\
+--     & \text{(when $initialHeap$ is a heap including all NGlobals for the supercombinators in a program)}\\
+--     & \text{(when $initialGlobal$ is a global including all supercombinators in a program)}
+--     \end{align}
+--     \]
+--
 -- __TODO: make this G-Machine be parallel__
 
 -- $operationalSemantics


### PR DESCRIPTION
**Fixed Issue(s)**
Fixes partially #107.

**Root of the Bug(s)**
- Wrong selection for the structure of `GMachineMonadT`
- Incorrect semantics of some instructions

**Previous Behaviour**
The interpreter is not able to be implemented.

**Current Behaviour**
The interpreter is implemented, and able to execute simple programs.

**Desktop (please complete the following information):**
 - OS: Manjaro
 - Minicute Version: 0.1.0.0
 - Underlying Compiler Version: LTS 14.7
