### PR TITLE
Remove Pretty class from prettyprinter

### DIFF
--- a/extensions/prettyprinter/lib/Data/Text/Prettyprint/Doc/Minicute.hs
+++ b/extensions/prettyprinter/lib/Data/Text/Prettyprint/Doc/Minicute.hs
@@ -1,31 +1,198 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- |
 -- Additional prettyprinter functions for miniCUTE compiler
 module Data.Text.Prettyprint.Doc.Minicute
-  ( PrettyPrec( .. )
-  , prettyShow
+  ( PrettyMC( .. )
+  , prettyMC0
+  , prettyListMC0
+
   , prettyIndent
   ) where
 
+import Data.Functor.Const
+import Data.Functor.Identity
+import Data.List.NonEmpty ( NonEmpty(..) )
+import Data.Maybe
 import Data.Text.Prettyprint.Doc
+import Data.Void
+import GHC.Int
+import GHC.Natural
+import GHC.Word
 
-import qualified Data.Text.Prettyprint.Doc.Render.String as PPS
-
--- |
--- 'PrettyPrec' class is a variation class of 'Pretty' for types that require precedence to print prettily.
-class (Pretty a) => PrettyPrec a where
-  prettyPrec :: Int -> a -> Doc ann
-  prettyPrec _ = pretty
-  {-# INLINABLE prettyPrec #-}
-
-  prettyPrec0 :: a -> Doc ann
-  prettyPrec0 = prettyPrec 0
-  {-# INLINABLE prettyPrec0 #-}
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LazyText
 
 -- |
--- A function to show input prettily.
-prettyShow :: (Pretty a) => a -> String
-prettyShow = PPS.renderString . layoutPretty defaultLayoutOptions . pretty
-{-# INLINABLE prettyShow #-}
+-- 'PrettyMC' (which stands for Pretty MiniCute) class is
+-- a variation class of 'Pretty' for miniCUTE types,
+-- which require a precedence to print prettily.
+class PrettyMC a where
+  {-# MINIMAL prettyMC #-}
+  prettyMC :: Int -> a -> Doc ann
+  prettyListMC :: Int -> [a] -> Doc ann
+  prettyListMC p = align . list . fmap (prettyMC p)
+  {-# INLINABLE prettyListMC #-}
+
+prettyMC0 :: (PrettyMC a) => a -> Doc ann
+prettyMC0 = prettyMC 0
+{-# INLINABLE prettyMC0 #-}
+
+prettyListMC0 :: (PrettyMC a) => [a] -> Doc ann
+prettyListMC0 = prettyListMC 0
+{-# INLINABLE prettyListMC0 #-}
+
+instance PrettyMC Bool where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Char where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Double where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Float where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Int where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Int8 where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Int16 where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Int32 where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Int64 where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Integer where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Natural where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Word where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Word8 where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Word16 where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Word32 where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Word64 where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC () where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Void where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC Text.Text where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance PrettyMC LazyText.Text where
+  prettyMC _ = pretty
+  {-# INLINABLE prettyMC #-}
+  prettyListMC _ = prettyList
+  {-# INLINABLE prettyListMC #-}
+
+instance (PrettyMC a) => PrettyMC [a] where
+  prettyMC = prettyListMC
+  {-# INLINABLE prettyMC #-}
+
+instance (PrettyMC a) => PrettyMC (Maybe a) where
+  prettyMC p = foldMap (prettyMC p)
+  {-# INLINABLE prettyMC #-}
+  prettyListMC p = prettyListMC p . catMaybes
+  {-# INLINABLE prettyListMC #-}
+
+instance (PrettyMC a) => PrettyMC (Identity a) where
+  prettyMC p = prettyMC p . runIdentity
+  {-# INLINABLE prettyMC #-}
+
+instance (PrettyMC a) => PrettyMC (NonEmpty a) where
+  prettyMC p = prettyListMC p . NonEmpty.toList
+  {-# INLINABLE prettyMC #-}
+
+instance (PrettyMC a1, PrettyMC a2) => PrettyMC (a1, a2) where
+  prettyMC p (x1, x2) = tupled [prettyMC p x1, prettyMC p x2]
+  {-# INLINABLE prettyMC #-}
+
+instance (PrettyMC a1, PrettyMC a2, PrettyMC a3) => PrettyMC (a1, a2, a3) where
+  prettyMC p (x1, x2, x3) = tupled [prettyMC p x1, prettyMC p x2, prettyMC p x3]
+  {-# INLINABLE prettyMC #-}
+
+instance (PrettyMC a) => PrettyMC (Const a b) where
+  prettyMC p = prettyMC p . getConst
+  {-# INLINABLE prettyMC #-}
+
 
 -- |
 -- @prettyIndent doc@ make a document indented with an appropriate size.

--- a/extensions/prettyprinter/package.yaml
+++ b/extensions/prettyprinter/package.yaml
@@ -52,6 +52,7 @@ library:
   dependencies:
     - prettyprinter >= 1.2 && < 2
     - template-haskell >= 2.14 && < 3
+    - text >= 1.2 && < 2
 
 # internal-libraries:
 

--- a/main-packages/common-syntax/lib/Minicute/Data/Common.hs
+++ b/main-packages/common-syntax/lib/Minicute/Data/Common.hs
@@ -23,9 +23,11 @@ module Minicute.Data.Common
 import Control.Lens.TH
 import Data.Data
 import Data.String ( IsString(..) )
-import Data.Text.Prettyprint.Doc ( Pretty(..) )
+import Data.Text.Prettyprint.Doc.Minicute
 import GHC.Generics
 import Language.Haskell.TH.Syntax
+
+import qualified Data.Text.Prettyprint.Doc as PP
 
 -- |
 -- miniCUTE identifier type.
@@ -48,8 +50,8 @@ instance IsString Identifier where
 instance Semigroup Identifier where
   (Identifier a) <> (Identifier b) = Identifier (a <> b)
 
-instance Pretty Identifier where
-  pretty (Identifier v) = pretty v
+instance PrettyMC Identifier where
+  prettyMC _ (Identifier v) = prettyMC0 v
 
 
 -- |

--- a/main-packages/common-syntax/package.yaml
+++ b/main-packages/common-syntax/package.yaml
@@ -56,6 +56,7 @@ library:
     - megaparsec >= 7.0 && < 8
     - parser-combinators
     - prettyprinter >= 1.2 && < 2
+    - prettyprinter-minicute == 0.1.0.0
     - template-haskell >= 2.14 && < 3
 
 # internal-libraries:

--- a/main-packages/minicute-compiler/minicute/Main.hs
+++ b/main-packages/minicute-compiler/minicute/Main.hs
@@ -2,7 +2,7 @@ module Main
   ( main
   ) where
 
-import Data.Text.Prettyprint.Doc.Minicute ( prettyShow )
+import Data.Text.Prettyprint.Doc.Minicute ( prettyMC0 )
 import Minicute.Parser.Minicute.Parser ( mainProgramMC )
 import Minicute.Transpilers.Lifting.Lambda ( lambdaLifting )
 import System.Environment
@@ -27,12 +27,12 @@ compile handle = do
       putStrLn "program by show:"
       print program
       putStrLn "program by pretty printing:"
-      putStrLn (prettyShow program)
+      print (prettyMC0 program)
       let liftedProgram = lambdaLifting program
       putStrLn "lifted program by show:"
       print liftedProgram
       putStrLn "lifted program by pretty printing:"
-      putStrLn (prettyShow liftedProgram)
+      print (prettyMC0 liftedProgram)
     Left err -> do
       putStrLn "error:"
       putStrLn (errorBundlePretty err)

--- a/main-packages/minicute-syntax/lib/Minicute/Data/Minicute/Program.hs
+++ b/main-packages/minicute-syntax/lib/Minicute/Data/Minicute/Program.hs
@@ -36,7 +36,7 @@ import Control.Lens.Tuple
 import Control.Lens.Type
 import Control.Lens.Wrapped
 import Data.Data
-import Data.Text.Prettyprint.Doc ( Pretty(..) )
+import Data.Text.Prettyprint.Doc.Minicute
 import GHC.Generics
 import Language.Haskell.TH.Syntax
 import Minicute.Data.Minicute.Expression
@@ -74,18 +74,18 @@ type MainSupercombinatorMC = SupercombinatorMC Identifier
 -- A supercombinator of 'MainExpressionLLMC'
 type MainSupercombinatorLLMC = SupercombinatorLLMC Identifier
 
-instance (Pretty a, Pretty (expr a)) => Pretty (Supercombinator expr a) where
-  pretty (Supercombinator (scId, argBinders, expr))
+instance (PrettyMC a, PrettyMC (expr a)) => PrettyMC (Supercombinator expr a) where
+  prettyMC _ (Supercombinator (scId, argBinders, expr))
     = PP.hcat
-      [ pretty scId
+      [ prettyMC0 scId
       , if null argBinders
         then PP.emptyDoc
         else PP.space
-      , PP.hsep . fmap pretty $ argBinders
+      , PP.hsep . fmap prettyMC0 $ argBinders
       , PP.space
       , PP.equals
       , PP.space
-      , pretty expr
+      , prettyMC0 expr
       ]
 
 
@@ -114,8 +114,8 @@ type MainProgramMC = ProgramMC Identifier
 -- A program of 'MainExpressionLLMC'
 type MainProgramLLMC = ProgramLLMC Identifier
 
-instance (Pretty a, Pretty (expr a)) => Pretty (Program expr a) where
-  pretty (Program scs) = PP.vcat . PP.punctuate PP.semi . fmap pretty $ scs
+instance (PrettyMC a, PrettyMC (expr a)) => PrettyMC (Program expr a) where
+  prettyMC _ (Program scs) = PP.vcat . PP.punctuate PP.semi . fmap prettyMC0 $ scs
 
 
 makeWrapped ''Supercombinator

--- a/main-packages/minicute-syntax/test/Minicute/PrettySpec.hs
+++ b/main-packages/minicute-syntax/test/Minicute/PrettySpec.hs
@@ -26,10 +26,10 @@ programMCTest name programString = do
   describe ("of " <> name) $ do
     it "prints re-parsable text" $ do
       program <- parseProgramMC programString
-      parse P.mainProgramMC "" (PP.prettyShow program) `shouldParse` program
+      parse P.mainProgramMC "" (show (PP.prettyMC0 program)) `shouldParse` program
     it "prints expected text" $ do
       program <- parseProgramMC programString
-      PP.prettyShow program `shouldBe` programString
+      show (PP.prettyMC0 program) `shouldBe` programString
   where
     parseProgramMC :: String -> IO MainProgramMC
     parseProgramMC ps = do


### PR DESCRIPTION
**Resolved Issue(s)**
Resolves #128.

**Is your refactoring related to a problem? Please describe.**
See the issue.

**Describe the solution you chose**
- Removing `Pretty` instances
- Renaming `PrettyPrec` class with `PrettyMC` to limit application of the class.
- Removing constraint of `PrettyMC` class.

**Additional context**
Do we need any annotation for pretty printing?